### PR TITLE
Revert "Send email notifications of broken links"

### DIFF
--- a/eahub/config/settings.py
+++ b/eahub/config/settings.py
@@ -43,7 +43,6 @@ MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.BrokenLinkEmailsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",


### PR DESCRIPTION
Reverts rtcharity/eahub.org#292

The emails are just uselessly spamming us. If I can figure out how to make them report the end-user IP then they might be useful.

Related to #321.