### PR TITLE
229 django forms

### DIFF
--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -534,7 +534,21 @@ form .alert ul {
 .login-info a {
   color: white;
 }
-
+.help-block {
+  color: #856404;
+  background-color: #fff3cd;
+  border-color: #ffeeba;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
+  border: 1px solid transparent;
+  border-radius: .25rem;
+}
+.help-block strong {
+  font-weight: 500;
+}
+#hint_id_password2 {
+  display: none;
+}
 .password-reset form {
   margin-bottom: 20px;
 }

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -514,6 +514,10 @@ form .alert ul {
   height: 30px;
 }
 
+#div_id_subscribed_to_email_updates {
+  margin-left: 20px;
+}
+
 /* registration */
 .login-danger {
   background-color: #E4F5B1;

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -476,6 +476,18 @@ body {
   display: block;
 }
 
+.control-group {
+  margin-bottom: 10px;
+}
+
+form .image_upload {
+  margin-bottom: 10px !important;
+}
+
+form .subscription {
+  margin-left: 20px;
+}
+
 /* registration */
 .login-danger {
   background-color: #E4F5B1;

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -488,6 +488,23 @@ form .subscription {
   margin-left: 20px;
 }
 
+form .btn-update {
+  margin-top: 15px;
+}
+
+form input, textarea {
+  width: 100%;
+}
+
+form .checkboxinput {
+  width: 20px;
+}
+
+#id_image {
+  padding-bottom: 35px;
+  height: 30px;
+}
+
 /* registration */
 .login-danger {
   background-color: #E4F5B1;

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -492,12 +492,8 @@ form .btn-update {
   margin-top: 15px;
 }
 
-form input, textarea {
+form .textInput, .textarea {
   width: 100%;
-}
-
-form .checkboxinput {
-  width: 20px;
 }
 
 #id_image {

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -496,6 +496,19 @@ form .textInput, .textarea {
   width: 100%;
 }
 
+form .alert-error {
+  margin-bottom: 20px;
+}
+
+form .alert ul {
+  list-style: none;
+  margin-left: 0px;
+  color: #a94442;
+  background-color: #f2dede;
+  border-color: #ebccd1;
+  padding: 10px 10px 10px 10px;
+}
+
 #id_image {
   padding-bottom: 35px;
   height: 30px;

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -523,6 +523,8 @@ form .alert ul {
   background-color: #E4F5B1;
   border: none;
   color: black;
+  padding: .75rem 1.25rem;
+  margin-bottom: 1rem;
 }
 
 .login-info {
@@ -535,13 +537,11 @@ form .alert ul {
   color: white;
 }
 .help-block {
-  color: #856404;
-  background-color: #fff3cd;
-  border-color: #ffeeba;
+  background-color: #E4F5B1;
+  border: none;
+  color: black;
   padding: .75rem 1.25rem;
   margin-bottom: 1rem;
-  border: 1px solid transparent;
-  border-radius: .25rem;
 }
 .help-block strong {
   font-weight: 500;

--- a/eahub/config/build_settings.py
+++ b/eahub/config/build_settings.py
@@ -23,4 +23,5 @@ STATIC_ROOT = "/static/"
 STATIC_URL = "/static/"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 
+# django-crispy-forms
 CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/eahub/config/build_settings.py
+++ b/eahub/config/build_settings.py
@@ -12,6 +12,7 @@ INSTALLED_APPS = [
     "eahub.base.apps.BaseConfig",
     "eahub.localgroups.apps.LocalGroupsConfig",
     "eahub.profiles.apps.ProfilesConfig",
+    "crispy_forms",
 ]
 
 # Core settings: security
@@ -21,3 +22,5 @@ SECRET_KEY = b"build_secret_key"
 STATIC_ROOT = "/static/"
 STATIC_URL = "/static/"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
+
+CRISPY_TEMPLATE_PACK = 'bootstrap4'

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -33,7 +33,7 @@ class EditProfileForm(forms.ModelForm):
             'subscribed_to_email_updates',
         )
         widgets = {
-            'summary': forms.Textarea(attrs={'rows': 7}),
+            'summary': forms.Textarea(attrs={'rows': 7, 'placeholder': "In West Philadelphia born and raised. On the playground is where I spent most of my days."}),
         }
         labels = {
             'city_or_town': ('City/Town'),

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -49,6 +49,9 @@ class EditProfileCauseAreasForm(forms.ModelForm):
         fields = (
             'available_to_volunteer',
         )
+        labels = {
+            'available_to_volunteer': ('Available to volunteer:')
+        }
 
 
 class EditProfileCareerForm(forms.ModelForm):
@@ -57,6 +60,9 @@ class EditProfileCareerForm(forms.ModelForm):
         fields = (
             'open_to_job_offers',
         )
+        labels = {
+            'open_to_job_offers': ('Open to job offers:')
+        }
 
 
 class EditProfileCommunityForm(forms.ModelForm):
@@ -65,7 +71,9 @@ class EditProfileCommunityForm(forms.ModelForm):
         fields = (
             'available_as_speaker',
         )
-
+        labels = {
+            'available_as_speaker': ('Available as speaker:')
+        }
 
 class DeleteProfileForm(forms.Form):
     confirm = forms.CharField(max_length=100)

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -32,13 +32,20 @@ class EditProfileForm(forms.ModelForm):
             'city_or_town', 'country',
             'subscribed_to_email_updates',
         )
+        widgets = {
+            'summary': forms.Textarea(attrs={'rows': 7}),
+        }
+        labels = {
+            'city_or_town': ('City/Town'),
+            'subscribed_to_email_updates': ('Send me email updates about the EA Hub'),
+        }
 
 
 class EditProfileCauseAreasForm(forms.ModelForm):
     class Meta:
         model = Profile
         fields = (
-            'available_to_volunteer',           
+            'available_to_volunteer',
         )
 
 

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -33,6 +33,8 @@ class EditProfileForm(forms.ModelForm):
             'subscribed_to_email_updates',
         )
         widgets = {
+            'city_or_town': forms.TextInput(attrs={'placeholder': 'London'}),
+            'country': forms.TextInput(attrs={'placeholder': 'UK'}),
             'summary': forms.Textarea(attrs={'rows': 7, 'placeholder': "In West Philadelphia born and raised. On the playground is where I spent most of my days."}),
         }
         labels = {

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -20,7 +20,7 @@ class ProfileCreationForm(CaseInsensitiveUsernameFieldCreationForm):
 
     class Meta(CaseInsensitiveUsernameFieldCreationForm.Meta):
         model = User
-        fields = ['email']
+        fields = ['name', 'email']
 
 
 class EditProfileForm(forms.ModelForm):

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -7,7 +7,7 @@ from ..base.models import User
 class ProfileCreationForm(CaseInsensitiveUsernameFieldCreationForm):
 
     name = forms.CharField(max_length=200)
-    subscribed_to_email_updates = forms.BooleanField(required=False)
+    subscribed_to_email_updates = forms.BooleanField(required=False, label='Send me email updates about the EA Hub')
 
     def save(self, commit=True):
         if not commit:

--- a/eahub/templates/eahub/delete_profile.html
+++ b/eahub/templates/eahub/delete_profile.html
@@ -8,6 +8,8 @@
 
 <p>For privacy reasons, we do not keep copies of any data that you've actively removed from the hub platform. For this reason, please be absolutely sure it’s what you want to do before confirming the deletion of your account.</p>
 
-<br>
-<button type="submit" class="btn btn-default">I am sure, permanently delete my account</button>
 {% endblock %}
+
+<br>
+
+{% block submit %}I am sure, permanently delete my account{% endblock %}

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -9,7 +9,7 @@
 
 {{ form.name|as_crispy_field }}
 
-<div class="field">
+<div class="field image_upload">
   <label for="id_image">Image</label>
   <input type="file" name="image" id="id_image" class="form-control">
   {% if form.image.errors %}
@@ -25,8 +25,9 @@
 
 {{ form.summary|as_crispy_field }}
 
-
+<div class="subscription">
 {{ form.subscribed_to_email_updates|as_crispy_field }}
+</div>
 
 <button type="submit" class="btn btn-default">Update</button>
 <div class="privacy-note">

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -29,7 +29,10 @@
 {{ form.subscribed_to_email_updates|as_crispy_field }}
 </div>
 
-<button type="submit" class="btn btn-default">Update</button>
+{% endblock %}
+
+{% block form_privacy_note %}
+
 <div class="privacy-note">
   <b>Note:</b> All profile information is public.
   Read more about our <a href="{% url 'privacyPolicy' %}">privacy policy</a>.

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -25,9 +25,7 @@
 
 {{ form.summary|as_crispy_field }}
 
-<div class="subscription">
 {{ form.subscribed_to_email_updates|as_crispy_field }}
-</div>
 
 {% endblock %}
 

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -31,6 +31,8 @@
 
 {% endblock %}
 
+{% block submit%}Update{% endblock%}
+
 {% block form_privacy_note %}
 
 <div class="privacy-note">

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -2,17 +2,12 @@
 
 {% block title %}Edit Profile{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
 
-<div class="field">
-    <label for="id_name" class="required_field">Name</label>
-    <input type="text" name="name" id="id_name" class="form-control" placeholder="Peter" value="{{ form.name.value }}" maxlength="50" required autofocus>
-    {% if form.name.errors %}
-        {% for error in form.name.errors %}
-        <div class="alert alert-danger">{{ error }}</div>
-        {% endfor %}
-    {% endif %}
-</div>
+
+{{ form.name|as_crispy_field }}
 
 <div class="field">
   <label for="id_image">Image</label>
@@ -24,45 +19,14 @@
   {% endif %}
 </div>
 
-<div class="field">
-  <label for="id_city_or_town">City/town</label>
-  <input type="text" name="city_or_town" id="id_city_or_town" class="form-control" value="{{ form.city_or_town.value|default_if_none:'' }}" placeholder="London" maxlength="50">
-  {% if form.city_or_town.errors %}
-    {% for error in form.city_or_town.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
+{{ form.city_or_town|as_crispy_field }}
 
-<div class="field">
-  <label for="id_country">Country</label>
-  <input type="text" name="country" id="id_country" class="form-control" value="{{ form.country.value|default_if_none:'' }}" placeholder="United Kingdom" maxlength="50">
-  {% if form.country.errors %}
-    {% for error in form.country.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
+{{ form.country|as_crispy_field }}
 
-<div class="field">
-  <label for="id_summary">Summary</label>
-  <textarea type="text" name="summary" id="id_summary" class="form-control" rows="4" placeholder='In West Philadelphia born and raised
-On the playground is where I spent most of my days' maxlength="5000">{{ form.summary.value }}</textarea>
-  {% if form.summary.errors %}
-    {% for error in form.summary.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
+{{ form.summary|as_crispy_field }}
 
-<div class="field">
-  <label>{{ form.subscribed_to_email_updates }} Send me email updates about the EA Hub</label>
-  {% if form.subscribed_to_email_updates.errors %}
-    {% for error in form.subscribed_to_email_updates.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
+
+{{ form.subscribed_to_email_updates|as_crispy_field }}
 
 <button type="submit" class="btn btn-default">Update</button>
 <div class="privacy-note">

--- a/eahub/templates/eahub/edit_profile_career.html
+++ b/eahub/templates/eahub/edit_profile_career.html
@@ -2,6 +2,8 @@
 
 {% block title %}Career{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
 
 <div class="field">
@@ -13,19 +15,17 @@
     </select>
 </div>
 
-<div class="field">
-  <label for="id_open_to_job_offers">Open to job offers:</label>
-  <select class="form-control" name="open_to_job_offers">
-    <option value="" {% if profile.open_to_job_offers == None %}selected{% endif %}>N/A</option>
-    <option value="True" {% if profile.open_to_job_offers == 1 %}selected{% endif %}>Yes</option>
-    <option value="False" {% if profile.open_to_job_offers == 0 %}selected{% endif %}>No</option>
-  </select>
-</div>
-<button type="submit" class="btn btn-default">Update</button>
+{{ form.open_to_job_offers|as_crispy_field }}
+
+{% endblock %}
+
+{% block submit%}Update{% endblock%}
+
+{% block form_privacy_note %}
+
 <div class="privacy-note">
   <b>Note:</b> All profile information, including your openness to receiving job offers, is public.
   Read more about our <a href="{% url 'privacyPolicy' %}">privacy policy</a>.
 </div>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 {% endblock %}

--- a/eahub/templates/eahub/edit_profile_cause_areas.html
+++ b/eahub/templates/eahub/edit_profile_cause_areas.html
@@ -2,6 +2,8 @@
 
 {% block title %}Cause Areas{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
 
 {{ form.errors }}
@@ -24,19 +26,17 @@
   </select>
 </div>
 
-<div class="field">
-  <label for="id_available_to_volunteer">Available to volunteer:</label>
-  <select class="form-control" name="available_to_volunteer">
-    <option value="" {% if profile.available_to_volunteer == None %}selected{% endif %}>N/A</option>
-    <option value="True" {% if profile.available_to_volunteer == 1 %}selected{% endif %}>Yes</option>
-    <option value="False" {% if profile.available_to_volunteer == 0 %}selected{% endif %}>No</option>
-  </select>
-</div>
-<button type="submit" class="btn btn-default">Update</button>
+{{ form.available_to_volunteer|as_crispy_field }}
+
+{% endblock %}
+
+{% block submit%}Update{% endblock%}
+
+{% block form_privacy_note %}
+
 <div class="privacy-note">
   <b>Note:</b> All profile information is public.
   Read more about our <a href="{% url 'privacyPolicy' %}">privacy policy</a>.
 </div>
 
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 {% endblock %}

--- a/eahub/templates/eahub/edit_profile_community.html
+++ b/eahub/templates/eahub/edit_profile_community.html
@@ -2,18 +2,18 @@
 
 {% block title %}Community{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
 
-<div class="field">
-  <label for="id_available_as_speaker">Available as speaker:</label>
-  <select class="form-control" name="available_as_speaker">
-    <option value="" {% if profile.available_as_speaker == None %}selected{% endif %}>N/A</option>
-    <option value="True" {% if profile.available_as_speaker == True %}selected{% endif %}>Yes</option>
-    <option value="False" {% if profile.available_as_speaker == False %}selected{% endif %}>No</option>
-  </select>
-</div>
+{{ form.available_as_speaker|as_crispy_field }}
 
-<button type="submit" class="btn btn-default">Update</button>
+{% endblock %}
+
+{% block submit%}Update{% endblock%}
+
+{% block form_privacy_note %}
+
 <div class="privacy-note">
   <b>Note:</b> All profile information is public.
   Read more about our <a href="{% url 'privacyPolicy' %}">privacy policy</a>.

--- a/eahub/templates/eahub/edit_profile_community.html
+++ b/eahub/templates/eahub/edit_profile_community.html
@@ -6,7 +6,7 @@
 
 {% block form_fields %}
 
-{{ form.available_as_speaker|as_crispy_field }}
+{{ form|crispy }}
 
 {% endblock %}
 

--- a/eahub/templates/form.html
+++ b/eahub/templates/form.html
@@ -42,6 +42,8 @@
           {% csrf_token %}
           <h2>{% block title %}{% endblock %}</h2>
           {% block form_fields %}{% endblock %}
+          <button type="submit" class="btn btn-default btn-update">Update</button>
+          {% block form_privacy_note %}{% endblock %}
         </form>
     </div>
 </div>

--- a/eahub/templates/form.html
+++ b/eahub/templates/form.html
@@ -42,7 +42,7 @@
           {% csrf_token %}
           <h2>{% block title %}{% endblock %}</h2>
           {% block form_fields %}{% endblock %}
-          <button type="submit" class="btn btn-default btn-update">Update</button>
+          <button type="submit" class="btn btn-default btn-update">{% block submit %}{% endblock %}</button>
           {% block form_privacy_note %}{% endblock %}
         </form>
     </div>

--- a/eahub/templates/registration/login.html
+++ b/eahub/templates/registration/login.html
@@ -6,7 +6,17 @@
 
 {% block form_fields %}
 
-  {{ form|crispy }}
+{{ form.username|as_crispy_field }}
+
+{{ form.password|as_crispy_field }}
+
+<div class="field">
+  {% if form.non_field_errors %}
+    {% for error in form.non_field_errors %}
+        <div class="alert alert-danger login-danger">{{ error }}</div>
+    {% endfor %}
+  {% endif %}
+</div>
 
 {% endblock %}
 

--- a/eahub/templates/registration/login.html
+++ b/eahub/templates/registration/login.html
@@ -2,35 +2,15 @@
 
 {% block title %}Login{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
-<div class="field">
-  <label for="id_username">Email address</label>
-  <input type="username" name="username" id="id_username" class="form-control" placeholder="email" required autofocus>
-  {% if form.username.errors %}
-    {% for error in form.username.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-  <label for="id_password">Password</label>
-  <input type="password" name="password" id="id_password" class="form-control" placeholder="password" required>
-  {% if form.password.errors %}
-    {% for error in form.password.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-  {% if form.non_field_errors %}
-    {% for error in form.non_field_errors %}
-        <div class="alert alert-danger login-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<button type="submit" class="btn btn-default">Log in</button>
+
+  {{ form|crispy }}
+
 {% endblock %}
 
+{% block submit%}Log in{% endblock%}
 
 {% block content_after_form %}
 <div class="panel animated pulse">

--- a/eahub/templates/registration/signup.html
+++ b/eahub/templates/registration/signup.html
@@ -2,58 +2,12 @@
 
 {% block title %}Sign Up{% endblock %}
 
+{% load crispy_forms_tags %}
+
 {% block form_fields %}
-<div class="field">
-  <label for="id_name">Name</label>
-  <input type="text" name="name" id="id_name" class="form-control" required autofocus>
-  {% if form.name.errors %}
-    {% for error in form.name.errors %}
-      <div class="alert alert-danger login-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-    <label for="id_email">Email address</label>
-    <input type="email" name="email" id="id_email" class="form-control" required>
-    {% if form.email.errors %}
-      {% for error in form.email.errors %}
-        <div class="alert alert-danger login-danger">{{ error }}</div>
-      {% endfor %}
-    {% endif %}
-</div>
-<div class="field">
-  <label for="id_password1">Password</label>
-  <input type="password" name="password1" id="id_password1" class="form-control" required>
-  {% if form.password1.errors %}
-    {% for error in form.password1.errors %}
-      <div class="alert alert-danger login-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-  <label for="id_password2">Confirm Password</label>
-  <input type="password" name="password2" id="id_password2" class="form-control" required>
-  {% if form.password2.errors %}
-    {% for error in form.password2.errors %}
-      <div class="alert alert-danger login-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-  <label>{{ form.subscribed_to_email_updates }} Send me email updates about the EA Hub</label>
-  {% if form.subscribed_to_email_updates.errors %}
-    {% for error in form.subscribed_to_email_updates.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
-<div class="field">
-  {% if form.non_field_errors %}
-    {% for error in form.non_field_errors %}
-        <div class="alert alert-danger login-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
-</div>
+
+ {{ form|crispy}}
+
 <div class="field">
   <div class="g-recaptcha" data-sitekey="{{ recaptcha_site_key }}"></div>
   {% if 'captcha_error' in request.GET %}

--- a/eahub/templates/registration/signup.html
+++ b/eahub/templates/registration/signup.html
@@ -6,7 +6,7 @@
 
 {% block form_fields %}
 
- {{ form|crispy}}
+{{ form|crispy }}
 
 <div class="field">
   <div class="g-recaptcha" data-sitekey="{{ recaptcha_site_key }}"></div>
@@ -14,6 +14,7 @@
     <div class="alert alert-danger login-danger" style="max-width: 304px;">Captcha error</div>
   {% endif %}
 </div>
+
 {% endblock %}
 
 {% block submit%}Sign up{% endblock%}

--- a/eahub/templates/registration/signup.html
+++ b/eahub/templates/registration/signup.html
@@ -60,7 +60,12 @@
     <div class="alert alert-danger login-danger" style="max-width: 304px;">Captcha error</div>
   {% endif %}
 </div>
-<button type="submit" class="btn btn-default">Sign Up</button>
+{% endblock %}
+
+{% block submit%}Sign up{% endblock%}
+
+{% block form_privacy_note %}
+
 <div class="privacy-note">
   <b>Note:</b> Once you have signed up, your name will be public on the Hub.
   Read more about our <a href="{% url 'privacyPolicy' %}">privacy policy</a>.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ applicationinsights==0.11.7
 django-authtools==1.6.0
 django-autoslug==1.9.4
 django-enumfield==1.5
+django-crispy-forms>=1.7.2


### PR DESCRIPTION
addresses #229 

Aim was to replace html for forms by django-crispy forms. Ideally, each form would just be displayed by {{ form | crispy }} in the html.

For a couple of forms, I could not do this because rendering specific fields adequately through Django-crispy-forms proved difficult. In those cases I rendered those fields through html and all others fields in this form through {{ form.FIELDNAME | as_crispy_field }}. Those forms were:
- edit_profile.html. Problematic field: image upload (looks terrible with django forms and I couldn't figure out a non-hacky way to fix that)
- edit_profile_cause_areas.html: Problematic fields: cause areas and giving pledges taken. In django forms, they display the id of the cause area or giving pledge, not their name. Probably fixable, but couldn't figure it out.
- edit_profile_career: Problematic field: Expertise. Same problem as in previous file. 
- login.html: Alert appeared above email and password. Had to render it through html to fix its position

Independent of whether this can be simplified further, future additional forms can be simply implemented through django-forms with this PR.