### PR TITLE
Add migrations for local group and profile ordering

### DIFF
--- a/eahub/localgroups/migrations/0002_localgroup_ordering.py
+++ b/eahub/localgroups/migrations/0002_localgroup_ordering.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("localgroups", "0001_initial")]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="localgroup", options={"ordering": ["name", "slug"]}
+        )
+    ]

--- a/eahub/profiles/migrations/0004_profile_ordering.py
+++ b/eahub/profiles/migrations/0004_profile_ordering.py
@@ -1,0 +1,12 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("profiles", "0003_membership")]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="profile", options={"ordering": ["name", "slug"]}
+        )
+    ]


### PR DESCRIPTION
This should have been part of #397, but was omitted accidentally.