### PR TITLE
autofill reset email field

### DIFF
--- a/eahub/templates/registration/password_reset_form.html
+++ b/eahub/templates/registration/password_reset_form.html
@@ -13,3 +13,11 @@
 </form>
 </div>
 {% endblock %}
+
+{% block scripts %}
+  <script>
+    // Extract email address from https://eahub.org/profile/password_reset/#hello@email.com
+    // and set it to the email address input box (used for personalised reset password emails)
+    $('#id_email').val(window.location.href.split('#')[1])
+  </script>
+{% endblock %}


### PR DESCRIPTION
# Problem
- Issue https://github.com/rtcharity/eahub.org/issues/421
- We need a way to auto-fill the email field on the reset-passoword page so we can send mailshots to users to reset their password with little additional effort required on their end

# Solution
- Added some simple javascript to extract the email address from the url like `https://eahub.org/profile/password_reset/#hello@email.com` and fill in the input field

# Further steps
- Update the email we're sending to old users to include the `#hello@email.com` at the end of the URL
