### PR TITLE
Add clearing picture function

### DIFF
--- a/eahub/base/static/scripts/main.js
+++ b/eahub/base/static/scripts/main.js
@@ -48,3 +48,17 @@ var navbar = document.getElementById('navbar')
 menu_btn.addEventListener('click', function() {
   navbar.style.display = navbar.style.display == 'inline-block' ? 'none' : 'inline-block';
 })
+
+document.getElementById('image-change-toggle').addEventListener('click', function() {
+  var image_change = document.getElementById('image-change')
+  image_change.style.display = (image_change.style.display == "block") ? 'none' : 'block'
+})
+
+document.getElementById('id_image').addEventListener('change', function() {
+  if (image_form.value != '') {
+    var image_clear_div = document.getElementById('image-clear')
+    var image_clear_checkbox = document.getElementById('image-clear_id')
+    image_clear_div.style.display = 'none'
+    image_clear_checkbox.checked = false
+  }
+})

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -569,6 +569,20 @@ form .alert ul {
   padding: 10px 10px 10px 10px;
 }
 
+.image-clear {
+  display: block;
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
+.image-clear label {
+  font-weight: normal;
+}
+
+.image-change-btn {
+  display: block;
+}
+
 #id_image {
   padding-bottom: 35px;
   height: 30px;

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -9,15 +9,30 @@
 
 {{ form.name|as_crispy_field }}
 
-<div class="field image_upload">
-  <label for="id_image">Image</label>
+
+<label>Profile picture</label>
+{% if profile.image %}
+<button id="image-change-toggle" type="button" class="image-change-btn">Change current picture</button>
+
+<div class="field image_upload" id="image-change" style="display: none">
   <input type="file" name="image" id="id_image" class="form-control">
-  {% if form.image.errors %}
-    {% for error in form.image.errors %}
-      <div class="alert alert-danger">{{ error }}</div>
-    {% endfor %}
-  {% endif %}
 </div>
+
+<div class="image-clear" id="image-clear">
+  <input type="checkbox" name="image-clear" id="image-clear_id">
+  <label for="image-clear_id">Clear current picture</label>
+</div>
+{% else %}
+<div class="field image_upload">
+  <input type="file" name="image" id="id_image" class="form-control">
+</div>
+{% endif %}
+
+{% if form.image.errors %}
+  {% for error in form.image.errors %}
+    <div class="alert alert-danger">{{ error }}</div>
+  {% endfor %}
+{% endif %}
 
 {{ form.city_or_town|as_crispy_field }}
 


### PR DESCRIPTION
Signed-off-by: Sebastian <sebbecker@gmx.net>

closes #347 

- When user has previously chosen image gives option to clear image
- Removes the checkbox for clearing image when user selects an image
- Furthermore, adds a toggle for changing picture if one exists. Previously, users would see immediately "No file chosen" next to "Browse" when they come to edit_profile even if they currently have a picture, which might be confusing