### PR TITLE
 Import user redirect aliases from legacy Hub

### DIFF
--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -4,3 +4,4 @@ from . import models
 
 
 admin.site.register(models.Profile)
+admin.site.register(models.ProfileSlug)

--- a/eahub/profiles/migrations/0008_profile_slug.py
+++ b/eahub/profiles/migrations/0008_profile_slug.py
@@ -1,0 +1,74 @@
+from django.db import migrations
+from django.db import models
+from django.db.models import deletion
+from sluggable import fields as sluggable_fields
+
+
+def create_slugs(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    Profile = apps.get_model("profiles", "Profile")
+    ProfileSlug = apps.get_model("profiles", "ProfileSlug")
+    content_type_for_profile, _ = ContentType.objects.get_or_create(
+        app_label="profiles", model="Profile"
+    )
+    ProfileSlug.objects.bulk_create(
+        [
+            ProfileSlug(
+                content_type=content_type_for_profile,
+                object_id=profile.pk,
+                slug=profile.slug,
+                created=profile.user.date_joined,
+            )
+            for profile in Profile.objects.select_related("user")
+        ]
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("profiles", "0007_profile_is_public"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="profile",
+            name="slug",
+            field=sluggable_fields.SluggableField(unique=True),
+        ),
+        migrations.CreateModel(
+            name="ProfileSlug",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("object_id", models.PositiveIntegerField()),
+                (
+                    "slug",
+                    models.CharField(
+                        db_index=True, max_length=255, unique=True, verbose_name="URL"
+                    ),
+                ),
+                (
+                    "redirect",
+                    models.BooleanField(default=False, verbose_name="Redirection"),
+                ),
+                ("created", models.DateTimeField(auto_now_add=True)),
+                (
+                    "content_type",
+                    models.ForeignKey(
+                        on_delete=deletion.PROTECT, to="contenttypes.ContentType"
+                    ),
+                ),
+            ],
+            options={"abstract": False},
+        ),
+        migrations.RunPython(code=create_slugs, reverse_code=migrations.RunPython.noop),
+    ]

--- a/eahub/requirements.txt
+++ b/eahub/requirements.txt
@@ -24,3 +24,4 @@ django-crispy-forms>=1.7.2
 rules==2.0.1
 pytils==0.3
 mysqlclient==1.4.2.post1
+django-sluggable==0.6.1


### PR DESCRIPTION
This doesn't actually enable any redirects yet, but it does ensure that we can do so later without worrying about conflicts, even if people register new accounts in the meantime with what would otherwise be conflicting names.

Part of #428.