### PR TITLE
Use trailing slashes consistently in URLs

### DIFF
--- a/eahub/config/urls.py
+++ b/eahub/config/urls.py
@@ -16,7 +16,7 @@ urlpatterns = [
     url('accounts/password/reset/key/(?P<uidb36>[0-9A-Za-z]+)-(?P<key>.+)/$', views.CustomisedPasswordResetFromKeyView.as_view(), name='account_reset_password_from_key'),
     path('accounts/', include('allauth.urls')),
     path('profile/', include('eahub.profiles.urls')),
-    path('profiles', views.profiles, name='profiles'),
+    path('profiles/', views.profiles, name='profiles'),
     path('group/', include('eahub.localgroups.urls')),
     path('groups/', views.groups, name='groups'),
     path('admin/', admin.site.urls, name='admin'),

--- a/eahub/localgroups/urls.py
+++ b/eahub/localgroups/urls.py
@@ -4,17 +4,17 @@ from . import views
 
 
 urlpatterns = [
-    urls.path("new", views.LocalGroupCreateView.as_view(), name="localgroups_create"),
-    urls.path('<slug:slug>/claim', views.claim_group, name='claim_group'),
-    urls.path('<slug:slug>/report-inactive', views.report_group_inactive, name='report_group_inactive'),
-    urls.path("<slug:slug>", views.LocalGroupDetailView.as_view(), name="group"),
+    urls.path("new/", views.LocalGroupCreateView.as_view(), name="localgroups_create"),
+    urls.path('<slug:slug>/claim/', views.claim_group, name='claim_group'),
+    urls.path('<slug:slug>/report-inactive/', views.report_group_inactive, name='report_group_inactive'),
+    urls.path("<slug:slug>/", views.LocalGroupDetailView.as_view(), name="group"),
     urls.path(
-        "<slug:slug>/edit",
+        "<slug:slug>/edit/",
         views.LocalGroupUpdateView.as_view(),
         name="localgroups_update",
     ),
     urls.path(
-        "<slug:slug>/delete",
+        "<slug:slug>/delete/",
         views.LocalGroupDeleteView.as_view(),
         name="localgroups_delete",
     ),

--- a/eahub/profiles/urls.py
+++ b/eahub/profiles/urls.py
@@ -3,11 +3,11 @@ from . import views
 
 urlpatterns = [
     path('', views.MyProfileView, name='my_profile'),
-    path('edit', views.edit_profile, name='edit_profile'),
-    path('edit/cause_areas', views.edit_profile_cause_areas, name='edit_profile_cause_areas'),
-    path('edit/career', views.edit_profile_career, name='edit_profile_career'),
-    path('edit/community', views.edit_profile_community, name='edit_profile_community'),
-    path('delete', views.delete_profile, name='delete_profile'),
-    path('download', views.DownloadView, name='download_profile'),
-    path('<slug:slug>', views.ProfileDetailView.as_view(), name='profile'),
+    path('edit/', views.edit_profile, name='edit_profile'),
+    path('edit/cause_areas/', views.edit_profile_cause_areas, name='edit_profile_cause_areas'),
+    path('edit/career/', views.edit_profile_career, name='edit_profile_career'),
+    path('edit/community/', views.edit_profile_community, name='edit_profile_community'),
+    path('delete/', views.delete_profile, name='delete_profile'),
+    path('download/', views.DownloadView, name='download_profile'),
+    path('<slug:slug>/', views.ProfileDetailView.as_view(), name='profile'),
 ]


### PR DESCRIPTION
Personally I prefer not having a trailing slash, but a bunch of other Django stuff we're using includes them, and inconsistencies here are likely to lead to subtle bugs.

URLs with file extensions (favicon.ico and robots933456.txt) don't have trailing slashes.

Fixes: #518