### PR TITLE
Remove subscribed_to_email_updates from profiles

### DIFF
--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -16,16 +16,14 @@ class SignupForm(forms.Form):
 
     name = forms.CharField(max_length=200, label="Name", widget=forms.TextInput(attrs={'placeholder': 'Name'}), validators=[validate_sluggable_name])
     is_public = forms.BooleanField(required=False, label="Show my profile to the public", initial=True)
-    subscribed_to_email_updates = forms.BooleanField(required=False, label='Send me email updates about the EA Hub')
     captcha = fields.ReCaptchaField(label='')
 
-    field_order = ['name','email','password1','password2','is_public','subscribed_to_email_updates','captcha']
+    field_order = ['name','email','password1','password2','is_public','captcha']
 
     def signup(self, request, user):
         is_public = self.cleaned_data['is_public']
         name = self.cleaned_data['name']
-        subscribed_to_email_updates = self.cleaned_data['subscribed_to_email_updates']
-        Profile.objects.create(user=user, is_public=is_public, name=name, subscribed_to_email_updates=subscribed_to_email_updates)
+        Profile.objects.create(user=user, is_public=is_public, name=name)
 
 
 class EditProfileForm(forms.ModelForm):
@@ -36,7 +34,6 @@ class EditProfileForm(forms.ModelForm):
             'image', 'summary',
             'city_or_town', 'country',
             'is_public',
-            'subscribed_to_email_updates',
         )
         widgets = {
             'city_or_town': forms.TextInput(attrs={'placeholder': 'London'}),
@@ -46,7 +43,6 @@ class EditProfileForm(forms.ModelForm):
         labels = {
             'city_or_town': ('City/Town'),
             'is_public': "Show my profile to the public",
-            'subscribed_to_email_updates': ('Send me email updates about the EA Hub'),
         }
 
 

--- a/eahub/profiles/migrations/0010_remove_profile_subscribed_to_email_updates.py
+++ b/eahub/profiles/migrations/0010_remove_profile_subscribed_to_email_updates.py
@@ -1,0 +1,10 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("profiles", "0009_profile_validate_sluggable_name")]
+
+    operations = [
+        migrations.RemoveField(model_name="profile", name="subscribed_to_email_updates")
+    ]

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -266,7 +266,6 @@ class Profile(models.Model):
     giving_pledges = postgres_fields.ArrayField(
         enum.EnumField(GivingPledge), blank=True, default=list
     )
-    subscribed_to_email_updates = models.BooleanField(default=False)
     local_groups = models.ManyToManyField(LocalGroup, through='Membership', blank=True)
     legacy_record = models.PositiveIntegerField(
         null=True, default=None, editable=False, unique=True
@@ -356,7 +355,6 @@ class Profile(models.Model):
                         "giving_pledges": list(
                             map(GivingPledge.label, self.giving_pledges)
                         ),
-                        "subscribed_to_email_updates": self.subscribed_to_email_updates,
                         "member_of_local_groups": [
                             request.build_absolute_uri(local_group.get_absolute_uri())
                             for local_group in self.local_groups.all()

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -50,8 +50,6 @@ If you make your profile private but enter a location, an anonymous pin represen
   Everything in public profiles is public and searchable.
 </div>
 
-{{ form.subscribed_to_email_updates|as_crispy_field }}
-
 {% endblock %}
 
 {% block submit%}Update{% endblock%}


### PR DESCRIPTION
Mailchimp will be handling this from now on instead.

First deploy this to prod, then move the existing subscription data to Mailchimp, and only then run the migration.

Signed-off-by: Taymon A. Beal <taymon@google.com>