### PR TITLE
Redirect to previous page after user logs out

### DIFF
--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -98,7 +98,7 @@
           <li><a name="navbar_link" id="navbar_about" href="{% url 'about' %}"><i class="fa fa-info"></i> About</a></li>
           <li><a name="navbar_link" id="navbar_feedback" target="_blank" href="https://feedback.eahub.org"><i class="fa fa-comment"></i> Feedback</a></li>
           {% if user.is_authenticated %}
-            <li class="list-more-item"><a name="navbar_link" href="{% url 'account_logout' %}"><i class="fa fa-sign-out" id="logout"></i> Log out</a></li>
+            <li class="list-more-item"><a name="navbar_link" href="{% url 'account_logout' %}?next={% firstof request.path '/' %}"><i class="fa fa-sign-out" id="logout"></i> Log out</a></li>
           {% endif %}
         </ul>
       </div>


### PR DESCRIPTION
Mirroring the behaviour of [PR 781](https://github.com/rtcharity/eahub.org/pull/781)

If a user was on a page which required authentication, then logging out now redirects to the log in page.