### PR TITLE
Add privacy setting for local groups.

### DIFF
--- a/eahub/base/views.py
+++ b/eahub/base/views.py
@@ -37,7 +37,7 @@ class CustomisedPasswordChangeView(PasswordChangeView):
 
 
 def index(request):
-    groups_data = get_groups_data()
+    groups_data = get_groups_data(request.user)
     profiles_data = get_profiles_data(request.user)
     private_profiles = get_private_profiles(request.user)
     return render(
@@ -82,7 +82,7 @@ def profiles(request):
 
 
 def groups(request):
-    groups_data = get_groups_data()
+    groups_data = get_groups_data(request.user)
     return render(
         request,
         "eahub/groups.html",
@@ -94,8 +94,8 @@ def groups(request):
     )
 
 
-def get_groups_data():
-    rows = Group.objects.all()
+def get_groups_data(user):
+    rows = Group.objects.visible_to_user(user)
     map_data = [
         {
             "lat": x.lat,

--- a/eahub/localgroups/forms.py
+++ b/eahub/localgroups/forms.py
@@ -93,6 +93,7 @@ class LocalGroupForm(forms.ModelForm):
         fields = [
             "name",
             "is_active",
+            "is_public",
             "local_group_type",
             "city_or_town",
             "country",

--- a/eahub/localgroups/localgroups_test.py
+++ b/eahub/localgroups/localgroups_test.py
@@ -1,0 +1,70 @@
+import pytest
+
+from ..localgroups.models import LocalGroup
+from ..profiles.models import Profile
+
+
+# Create two users, and a public and private group: one user organizes both
+# groups. Test that each user can see the appropriate groups.
+# TODO: Test profile views too.
+@pytest.mark.nondestructive
+def test_group_visibility(client, django_user_model):
+    publicgroup_name = "public-group"
+    privategroup_name = "private-group"
+
+    profile1 = Profile.objects.create(user_id=1, name=profile1_name, is_public=True)
+    user1 = django_user_model.objects.create(
+        profile=profile1, password="testpassone", email="user1@example.com"
+    )
+
+    profile2 = Profile.objects.create(user_id=2, name="testusertwo", is_public=True)
+    user2 = django_user_model.objects.create(
+        profile=profile2, email="user2@example.com"
+    )
+
+    group_public = LocalGroup.objects.create(name=publicgroup_name, is_public=True)
+    group_public.organisers.set([user1])
+
+    assert group_public.slug == publicgroup_name
+
+    group_private = LocalGroup.objects.create(name=privategroup_name, is_public=False)
+    group_private.organisers.set([user1])
+
+    assert profile1.all_organised_groups().count() == 2
+    assert profile1.public_organised_groups().count() == 1
+    assert profile1.visible_organised_groups(user1).count() == 2
+    assert profile1.visible_organised_groups(user2).count() == 1
+
+    response = client.get("/group/%s/" % publicgroup_name)
+    assert response.status_code == 200
+
+    response = client.get("/group/%s/" % privategroup_name)
+    assert response.status_code == 404
+
+    response = client.get("/groups/")
+    assert publicgroup_name in str(response.content)
+    assert privategroup_name not in str(response.content)
+
+    client.force_login(user=user1)
+
+    response = client.get("/group/%s/" % publicgroup_name)
+    assert response.status_code == 200
+
+    response = client.get("/group/%s/" % privategroup_name)
+    assert response.status_code == 200
+
+    response = client.get("/groups/")
+    assert publicgroup_name in str(response.content)
+    assert privategroup_name in str(response.content)
+
+    client.force_login(user=user2)
+
+    response = client.get("/group/%s/" % publicgroup_name)
+    assert response.status_code == 200
+
+    response = client.get("/group/%s/" % privategroup_name)
+    assert response.status_code == 404
+
+    response = client.get("/groups/")
+    assert publicgroup_name in str(response.content)
+    assert privategroup_name not in str(response.content)

--- a/eahub/localgroups/localgroups_test.py
+++ b/eahub/localgroups/localgroups_test.py
@@ -8,27 +8,27 @@ from ..profiles.models import Profile
 # groups. Test that each user can see the appropriate groups.
 # TODO: Test profile views too.
 @pytest.mark.nondestructive
+@pytest.mark.django_db
 def test_group_visibility(client, django_user_model):
     publicgroup_name = "public-group"
     privategroup_name = "private-group"
 
-    profile1 = Profile.objects.create(user_id=1, name=profile1_name, is_public=True)
-    user1 = django_user_model.objects.create(
-        profile=profile1, password="testpassone", email="user1@example.com"
-    )
+    user1 = django_user_model.objects.create(email="user1@example.com")
+    profile1 = Profile.objects.create(user=user1, name="testuserone", is_public=True)
 
-    profile2 = Profile.objects.create(user_id=2, name="testusertwo", is_public=True)
-    user2 = django_user_model.objects.create(
-        profile=profile2, email="user2@example.com"
-    )
+    user2 = django_user_model.objects.create(email="user2@example.com")
+    Profile.objects.create(user=user2, name="testusertwo", is_public=True)
 
     group_public = LocalGroup.objects.create(name=publicgroup_name, is_public=True)
     group_public.organisers.set([user1])
+    group_public.save()
 
     assert group_public.slug == publicgroup_name
 
     group_private = LocalGroup.objects.create(name=privategroup_name, is_public=False)
     group_private.organisers.set([user1])
+    group_private.save()
+    user1.save()
 
     assert profile1.all_organised_groups().count() == 2
     assert profile1.public_organised_groups().count() == 1

--- a/eahub/localgroups/migrations/0004_localgroup_is_public.py
+++ b/eahub/localgroups/migrations/0004_localgroup_is_public.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("localgroups", "0003_localgroup_last_edited")]
+
+    operations = [
+        migrations.AddField(
+            model_name="localgroup",
+            name="is_public",
+            field=models.BooleanField(default=True),
+        )
+    ]

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -16,11 +16,19 @@ class LocalGroupType(enum.Enum):
     labels = {CITY: "City", COUNTRY: "Country", UNIVERSITY: "University"}
 
 
+class LocalGroupManager(models.Manager):
+    def visible_to_user(self, user):
+        if user.is_superuser:
+            return self.all()
+        return self.filter(models.Q(is_public=True) | models.Q(organisers__id=user.pk))
+
+
 class LocalGroup(models.Model):
 
     slug = autoslug.AutoSlugField(populate_from="name", unique=True)
     name = models.CharField(max_length=100)
     is_active = models.BooleanField(default=True)
+    is_public = models.BooleanField(default=True)
     organisers = models.ManyToManyField(
         settings.AUTH_USER_MODEL, through="Organisership", blank=True
     )
@@ -47,6 +55,8 @@ class LocalGroup(models.Model):
     last_edited = models.DateTimeField(
         auto_now=True, null=True, blank=True, editable=False
     )
+
+    objects = LocalGroupManager()
 
     class Meta:
         ordering = ["name", "slug"]

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -2,9 +2,15 @@ import rules
 
 
 @rules.predicate
+def localgroup_is_public(user, local_group):
+    return local_group.is_public
+
+
+@rules.predicate
 def is_organiser(user, local_group):
     return local_group.organisers.filter(pk=user.pk).exists()
 
 
+rules.add_perm("localgroups.view_local_group", localgroup_is_public | is_organiser)
 rules.add_perm("localgroups.change_local_group", is_organiser)
 rules.add_perm("localgroups.delete_local_group", is_organiser)

--- a/eahub/localgroups/urls.py
+++ b/eahub/localgroups/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
         views.report_group_inactive,
         name="report_group_inactive",
     ),
-    urls.path("<slug:slug>/", views.LocalGroupDetailView.as_view(), name="group"),
+    urls.path("<slug:slug>/", views.local_group_detail, name="group"),
     urls.path(
         "<slug:slug>/edit/",
         views.LocalGroupUpdateView.as_view(),

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -329,16 +329,24 @@ class Profile(models.Model):
         else:
             return "N/A"
 
-    def get_pretty_local_groups(self):
-        if self.local_groups:
-            return ", ".join(
-                [
-                    "{local_group}".format(local_group=x.name)
-                    for x in self.local_groups.all()
-                ]
-            )
-        else:
-            return "N/A"
+    def public_local_groups(self):
+        return self.local_groups.filter(is_public=True)
+
+    def visible_local_groups(self, user):
+        return self.local_groups.filter(
+            models.Q(is_public=True) | models.Q(organisers__id=user.pk)
+        )
+
+    def all_organised_groups(self):
+        return self.user.localgroup_set
+
+    def public_organised_groups(self):
+        return self.all_organised_groups().filter(is_public=True)
+
+    def visible_organised_groups(self, user):
+        return self.all_organised_groups().filter(
+            models.Q(is_public=True) | models.Q(organisers__id=user.pk)
+        )
 
     def write_data_export_zip(self, request, response):
         with zipfile.ZipFile(response, mode="w") as zip_file:

--- a/eahub/profiles/views.py
+++ b/eahub/profiles/views.py
@@ -33,7 +33,14 @@ def profile_detail_or_redirect(request, slug):
         raise Http404("No profile exists with that slug.")
     if slug_entry.redirect:
         return redirect("profile", slug=profile.slug, permanent=True)
-    return render(request, "eahub/profile.html", {"profile": profile})
+    return render(
+        request,
+        "eahub/profile.html",
+        {
+            "profile": profile,
+            "visible_organised_groups": profile.visible_organised_groups(request.user),
+        },
+    )
 
 
 def profile_redirect_from_legacy_record(request, legacy_record):

--- a/eahub/templates/eahub/edit_group.html
+++ b/eahub/templates/eahub/edit_group.html
@@ -9,7 +9,7 @@
 {{ form|crispy }}
 </div>
 <div class="privacy-note">
-  <b>Note:</b> All group information is public.
+  <b>Note:</b> All information for public groups is public.
   The organisers of a group can see who each other are, even if their profiles are private.
   Read more about our <a href="{% url 'privacy_policy' %}">privacy policy</a>.
 </div>

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -14,6 +14,9 @@
     <div class="col-xs-offset-2 col-xs-2">
       <img class="profile_picture" src="/static/images/group_avatar.png">
     </div>
+    {% if not group.is_public %}
+    <div class="privacy-banner hub-info" title="This group is not public. Click on 'Edit' to change your settings."><i class="fa fa-lock"></i>Private group</div>
+    {% endif %}
     <div class="col-xs-6">
       <h1 class="word-break">{{ group.name }}</h1>
       <div class="btn btn-default purple">

--- a/eahub/templates/eahub/profile.html
+++ b/eahub/templates/eahub/profile.html
@@ -125,30 +125,30 @@
           {% if profile.organisational_affiliations %}
           <div class="list"><div class="tag">Organisational affiliations:</div> {{ profile.get_pretty_organisational_affiliations }}</div>
           {% endif %}
-          {% if profile.local_groups.exists %}
+          {% if profile.public_local_groups.exists %}
           <div class="list turquoise-links">
             <div class="tag" style="display: block">Local group membership:</div>
-            {% if profile.local_groups.all.count == 1 %}
+            {% if profile.public_local_groups.count == 1 %}
               <a href="{% url 'group' profile.local_groups.first.slug %}">
-                {{profile.local_groups.first.name}}
+                {{profile.public_local_groups.first.name}}
               </a>
             {% else %}
-              {% for group in profile.local_groups.all %}
+              {% for group in profile.public_local_groups %}
                 <a class="list-item" href="{% url 'group' group.slug %}">{{group.name}}</a>
               {% endfor%}
             {% endif %}
           </div>
           {% endif %}
 
-          {% if profile.user.localgroup_set.exists %}
+          {% if visible_organised_groups.exists %}
           <div class="list turquoise-links">
             <div class="tag">Organiser of:</div>
-            {% if profile.user.localgroup_set.all.count == 1 %}
-              <a href="{% url 'group' profile.user.localgroup_set.first.slug %}">
-                {{profile.user.localgroup_set.first.name}}
+            {% if visible_organised_groups.all.count == 1 %}
+              <a href="{% url 'group' visible_organised_groups.first.slug %}">
+                {{visible_organised_groups.first.name}}
               </a>
             {% else %}
-              {% for group in profile.user.localgroup_set.all %}
+              {% for group in visible_organised_groups.all %}
                 <a class="list-item" href="{% url 'group' group.slug %}">{{group.name}}</a>
               {% endfor%}
             {% endif %}


### PR DESCRIPTION
Add an is_public field to local groups: if it's set to false, the group won't be visible except to its organisers.

Closes #776