### PR TITLE
Allow groups to be private

### DIFF
--- a/eahub/base/views.py
+++ b/eahub/base/views.py
@@ -137,7 +137,7 @@ def groups(request):
 
 
 def get_groups_data():
-    rows = Group.objects.all()
+    rows = Group.objects.filter(is_public=True)
     map_data = [
         {
             "lat": group.lat,

--- a/eahub/localgroups/migrations/0004_localgroup_is_public.py
+++ b/eahub/localgroups/migrations/0004_localgroup_is_public.py
@@ -1,0 +1,14 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("localgroups", "0003_localgroup_last_edited")]
+
+    operations = [
+        migrations.AddField(
+            model_name="localgroup",
+            name="is_public",
+            field=models.BooleanField(default=True),
+        )
+    ]

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -19,6 +19,7 @@ class LocalGroupType(enum.Enum):
 class LocalGroup(models.Model):
 
     slug = autoslug.AutoSlugField(populate_from="name", unique=True)
+    is_public = models.BooleanField(default=True)
     name = models.CharField(max_length=100)
     is_active = models.BooleanField(default=True)
     organisers = models.ManyToManyField(

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -39,13 +39,13 @@ class LocalGroupCreateView(auth_mixins.LoginRequiredMixin, edit_views.CreateView
 
 
 class LocalGroupDetailView(detail_views.DetailView):
-    model = LocalGroup
+    queryset = LocalGroup.objects.filter(is_public=True)
     template_name = "eahub/group.html"
     context_object_name = "group"
 
 
 class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.UpdateView):
-    model = LocalGroup
+    queryset = LocalGroup.objects.filter(is_public=True)
     form_class = LocalGroupForm
     template_name = "eahub/edit_group.html"
     permission_required = "localgroups.change_local_group"
@@ -60,7 +60,7 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
 
 
 class LocalGroupDeleteView(rules_views.PermissionRequiredMixin, edit_views.DeleteView):
-    model = LocalGroup
+    queryset = LocalGroup.objects.filter(is_public=True)
     template_name = "eahub/delete_group.html"
     success_url = urls.reverse_lazy("groups")
     permission_required = "localgroups.delete_local_group"
@@ -68,7 +68,7 @@ class LocalGroupDeleteView(rules_views.PermissionRequiredMixin, edit_views.Delet
 
 class ReportGroupAbuseView(ReportAbuseView):
     def profile(self):
-        return LocalGroup.objects.get(slug=self.kwargs["slug"])
+        return LocalGroup.objects.get(slug=self.kwargs["slug"], is_public=True)
 
     def get_type(self):
         return "group"
@@ -77,7 +77,7 @@ class ReportGroupAbuseView(ReportAbuseView):
 @login_required
 @require_POST
 def claim_group(request, slug):
-    group = get_object_or_404(LocalGroup, slug=slug)
+    group = get_object_or_404(LocalGroup, slug=slug, is_public=True)
     subject = "EA Group claimed: {0}".format(group.name)
     try:
         user_eahub_url = "https://{0}/profile/{1}".format(
@@ -116,7 +116,7 @@ def claim_group(request, slug):
 @login_required
 @require_POST
 def report_group_inactive(request, slug):
-    group = get_object_or_404(LocalGroup, slug=slug)
+    group = get_object_or_404(LocalGroup, slug=slug, is_public=True)
     subject = "EA Group reported as inactive: {0}".format(group.name)
     try:
         user_eahub_url = "https://{0}/profile/{1}".format(

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -79,7 +79,9 @@ class EditProfileCareerForm(forms.ModelForm):
 
 class EditProfileCommunityForm(forms.ModelForm):
     local_groups = CustomisedModelMultipleChoiceField(
-        queryset=LocalGroup.objects.all(), required=False, label="Local groups:"
+        queryset=LocalGroup.objects.filter(is_public=True),
+        required=False,
+        label="Local groups:",
     )
 
     class Meta:


### PR DESCRIPTION
The permissions are not sophisticated. A group can be either public or private. From a user's perspective, private groups don't exist; users can't create private groups, change the privacy setting of groups, or see, modify, or be aware of the existence of a group that's private, even if they're an organizer of it. Private groups do show up in the admin; admins can create private groups and can see and change everything about every group, including privacy settings.

Fixes: #776