### PR TITLE
Require approval for public profiles

### DIFF
--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -363,8 +363,14 @@ body {
   border: none;
   font-size: 1.1em;
 }
+.profile-action .list-group-item.disabled {
+  background-color: #777 !important;
+}
 .profile-action .list-group-item:hover {
   transform: scale(1.1);
+}
+.profile-action .list-group-item.disabled:hover {
+  transform: none;
 }
 .profile-action .list-group-item .fa {
   margin-right: 10px;

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -1,10 +1,22 @@
 import rules
 
+from ..profiles.models import Profile
+
 
 @rules.predicate
 def is_organiser(user, local_group):
     return local_group.organisers.filter(pk=user.pk).exists()
 
 
+@rules.predicate
+def is_approved(user):
+    try:
+        profile = user.profile
+    except Profile.DoesNotExist:
+        return False
+    return profile.is_approved
+
+
+rules.add_perm("localgroups.create_local_group", is_approved)
 rules.add_perm("localgroups.change_local_group", is_organiser)
 rules.add_perm("localgroups.delete_local_group", is_organiser)

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -18,10 +18,15 @@ from .forms import LocalGroupForm
 from .models import LocalGroup
 
 
-class LocalGroupCreateView(auth_mixins.LoginRequiredMixin, edit_views.CreateView):
+class LocalGroupCreateView(
+    auth_mixins.LoginRequiredMixin,
+    auth_mixins.PermissionRequiredMixin,
+    edit_views.CreateView,
+):
     model = LocalGroup
     form_class = LocalGroupForm
     template_name = "eahub/edit_group.html"
+    permission_required = "localgroups.create_local_group"
 
     def get_initial(self):
         initial = super().get_initial()

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -20,7 +20,9 @@ class SignupForm(forms.Form):
         validators=[validate_sluggable_name],
     )
     is_public = forms.BooleanField(
-        required=False, label="Show my profile to the public", initial=True
+        required=False,
+        label="Show my profile to the public after it is approved",
+        initial=True,
     )
     if hasattr(settings, "RECAPTCHA_PUBLIC_KEY"):
         captcha = fields.ReCaptchaField(label="", widget=widgets.ReCaptchaV3)

--- a/eahub/profiles/migrations/0014_profile_is_approved.py
+++ b/eahub/profiles/migrations/0014_profile_is_approved.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [("profiles", "0013_profile_fields_char_limit")]
+
+    operations = [
+        migrations.AddField(
+            model_name="profile",
+            name="is_approved",
+            field=models.BooleanField(default=True),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name="profile",
+            name="is_approved",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -239,7 +239,9 @@ class ProfileManager(models.Manager):
     def visible_to_user(self, user):
         if user.is_superuser:
             return self.all()
-        return self.filter(models.Q(is_public=True) | models.Q(user_id=user.pk))
+        return self.filter(
+            models.Q(is_public=True, is_approved=True) | models.Q(user_id=user.pk)
+        )
 
 
 class Profile(models.Model):
@@ -249,6 +251,7 @@ class Profile(models.Model):
         decider=ProfileSlug, populate_from="name", slugify=slugify_user, unique=True
     )
     is_public = models.BooleanField(default=True)
+    is_approved = models.BooleanField(default=False)
     name = models.CharField(max_length=200, validators=[validate_sluggable_name])
     image = thumbnail.ImageField(
         upload_to=upload_path.auto_cleaned_path_stripped_uuid4, blank=True
@@ -368,6 +371,7 @@ class Profile(models.Model):
                         "last_login": self.user.last_login.isoformat(),
                         "url": request.build_absolute_uri(self.get_absolute_url()),
                         "is_public": self.is_public,
+                        "is_approved": self.is_approved,
                         "name": self.name,
                         "city_or_town": self.city_or_town,
                         "country": self.country,

--- a/eahub/profiles/rules.py
+++ b/eahub/profiles/rules.py
@@ -2,8 +2,8 @@ import rules
 
 
 @rules.predicate
-def profile_is_public(user, profile):
-    return profile.is_public
+def profile_is_generally_visible(user, profile):
+    return profile.is_public and profile.is_approved
 
 
 @rules.predicate
@@ -11,4 +11,6 @@ def is_profile_of_user(user, profile):
     return user == profile.user
 
 
-rules.add_perm("profiles.view_profile", profile_is_public | is_profile_of_user)
+rules.add_perm(
+    "profiles.view_profile", profile_is_generally_visible | is_profile_of_user
+)

--- a/eahub/templates/eahub/edit_profile.html
+++ b/eahub/templates/eahub/edit_profile.html
@@ -51,7 +51,11 @@ If you make your profile private but enter a location, an anonymous pin represen
 {{ form.is_public|as_crispy_field }}
 
 <div class="privacy-note">
+  {% if profile.is_approved %}
   Everything in public profiles is public and searchable.
+  {% else %}
+  Everything in public profiles becomes public and searchable as soon as the profile is approved.
+  {% endif %}
 </div>
 
 {% endblock %}

--- a/eahub/templates/eahub/edit_profile_career.html
+++ b/eahub/templates/eahub/edit_profile_career.html
@@ -39,7 +39,12 @@
 {% block form_privacy_note %}
 {% if profile.is_public %}
 <div class="privacy-note">
-  You are showing this information to the public. You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
+  {% if profile.is_approved %}
+  You are showing this information to the public.
+  {% else %}
+  This information will become publicly visible as soon as your profile is approved.
+  {% endif %}
+  You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
 </div>
 {% endif %}
 {% endblock %}

--- a/eahub/templates/eahub/edit_profile_cause_areas.html
+++ b/eahub/templates/eahub/edit_profile_cause_areas.html
@@ -41,7 +41,12 @@
 {% block form_privacy_note %}
 {% if profile.is_public %}
 <div class="privacy-note">
-  You are showing this information to the public. You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
+  {% if profile.is_approved %}
+  You are showing this information to the public.
+  {% else %}
+  This information will become publicly visible as soon as your profile is approved.
+  {% endif %}
+  You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
 </div>
 {% endif %}
 {% endblock %}

--- a/eahub/templates/eahub/edit_profile_community.html
+++ b/eahub/templates/eahub/edit_profile_community.html
@@ -35,7 +35,12 @@
 {% block form_privacy_note %}
 {% if profile.is_public %}
 <div class="privacy-note">
-  You are showing this information to the public. You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
+  {% if profile.is_approved %}
+  You are showing this information to the public.
+  {% else %}
+  This information will become publicly visible as soon as your profile is approved.
+  {% endif %}
+  You can <a href="{% url 'edit_profile' %}">change your privacy settings</a>, or <a href="{% url 'privacy_policy' %}">read more about our privacy policy</a>.
 </div>
 {% endif %}
 {% endblock %}

--- a/eahub/templates/eahub/groups.html
+++ b/eahub/templates/eahub/groups.html
@@ -1,5 +1,7 @@
 {% extends 'base.html' %}
 
+{% load rules %}
+
 {% block content %}
 
 <br><br>
@@ -8,7 +10,16 @@
   <div class="row">
     <div class="col-sm-4 profile-action">
         <div class="list-group">
-          <a href="{% url 'localgroups_create' %}" class="list-group-item"><i class="fa fa-plus"></i> Create a Group</a>
+          {% if user.is_authenticated %}
+            {% has_perm 'localgroups.create_local_group' user as can_create_local_group %}
+            {% if can_create_local_group %}
+              <a href="{% url 'localgroups_create' %}" class="list-group-item"><i class="fa fa-plus"></i> Create a Group</a>
+            {% else %}
+              <span class="list-group-item disabled" title="You can't create a group until your profile is confirmed."><i class="fa fa-plus"></i> Create a Group</span>
+            {% endif %}
+          {% else %}
+            <span class="list-group-item disabled" title="You must be logged in to create a group."><i class="fa fa-plus"></i> Create a Group</span>
+          {% endif %}
         </div>
         <div class="list-group">
           <a href="https://resources.eahub.org" class="list-group-item"><i class="fa fa-book"></i> EA Resources</a>

--- a/eahub/templates/eahub/profile.html
+++ b/eahub/templates/eahub/profile.html
@@ -18,6 +18,8 @@
       {% endthumbnail %}
       {% if not profile.is_public %}
       <div class="privacy-banner hub-info" title="This profile is not public. Click on 'Edit' to change your settings."><i class="fa fa-lock"></i>Private profile</div>
+      {% elif not profile.is_approved %}
+      <div class="privacy-banner hub-info" title="This profile has not yet been approved, so other people can't see it yet."><i class="fa fa-lock"></i>Awaiting approval</div>
       {% endif %}
     </div>
     <div class="col-xs-12 col-md-6">

--- a/eahub/templates/eahub/profiles.html
+++ b/eahub/templates/eahub/profiles.html
@@ -63,6 +63,8 @@
           <a href="{% url 'profile' profile.slug %}">{{ profile.name }}</a>
           {% if not profile.is_public %}
           <span class="privacy-banner hub-info"><i class="fa fa-lock"></i>Private profile</span>
+          {% elif not profile.is_approved %}
+          <span class="privacy-banner hub-info"><i class="fa fa-lock"></i>Awaiting approval</span>
           {% endif %}
         </td>
         <td class="text-muted">

--- a/eahub/templates/eahub/talentsearch.html
+++ b/eahub/templates/eahub/talentsearch.html
@@ -35,6 +35,8 @@
             <a href="{% url 'profile' profile.slug %}">{{ profile.name }}</a>
             {% if not profile.is_public %}
             <span class="privacy-banner hub-info"><i class="fa fa-lock"></i>Private profile</span>
+            {% elif not profile.is_approved %}
+            <span class="privacy-banner hub-info"><i class="fa fa-lock"></i>Awaiting approval</span>
             {% endif %}
           </td>
           {% if include_summary %}


### PR DESCRIPTION
This includes a new migration. All profiles that already exist before the migration runs will be auto-approved. But any new ones created in the future will have to be approved manually.

Currently, approval works by going into the admin and checking the box for each individual profile.