### PR TITLE
Migrate to reCAPTCHA v3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       LEGACY_DATABASE_URL:
       LOCAL_GROUPS_AIRTABLE_API_KEY:
       LOCAL_GROUPS_AIRTABLE_BASE_KEY:
+      RECAPTCHA_V3_SECRET_KEY: 
+      RECAPTCHA_V3_SITE_KEY: 
       ADMINS: Local Admin=admin@example.com
       AZURE_CONNECTION_STRING: UseDevelopmentStorage=true;BlobEndpoint=objstore:8002
       AZURE_CONTAINER: media
@@ -34,8 +36,6 @@ services:
       LEAN_MANAGERS: Local Manager=leanmanager@example.com
       PYTEST_ADDOPTS: --driver=Remote
       PYTHONDONTWRITEBYTECODE: 'True'
-      RECAPTCHA_SECRET_KEY: 6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe
-      RECAPTCHA_SITE_KEY: 6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
       SECRET_KEY: development_secret_key
       SELENIUM_HOST: webdriver
   db:

--- a/eahub/base/static/styles/main.css
+++ b/eahub/base/static/styles/main.css
@@ -819,3 +819,7 @@ table td {
     display: block !important;
   }
 }
+
+.grecaptcha-badge {
+  visibility: hidden;
+}

--- a/eahub/config/settings.py
+++ b/eahub/config/settings.py
@@ -198,8 +198,16 @@ ACCOUNT_USER_MODEL_USERNAME_FIELD = None
 ACCOUNT_USERNAME_REQUIRED = False
 
 # Django reCAPTCHA
-RECAPTCHA_PRIVATE_KEY = env.str("RECAPTCHA_SECRET_KEY")
-RECAPTCHA_PUBLIC_KEY = env.str("RECAPTCHA_SITE_KEY")
+recaptcha_v3_secret_key = env.str("RECAPTCHA_V3_SECRET_KEY", default=None)
+recaptcha_v3_site_key = env.str("RECAPTCHA_V3_SITE_KEY", default=None)
+if recaptcha_v3_secret_key is not None and recaptcha_v3_site_key is not None:
+    RECAPTCHA_PRIVATE_KEY = recaptcha_v3_secret_key
+    RECAPTCHA_PUBLIC_KEY = recaptcha_v3_site_key
+    RECAPTCHA_REQUIRED_SCORE = 0.85
+elif recaptcha_v3_secret_key is not None or recaptcha_v3_site_key is not None:
+    raise exceptions.ImproperlyConfigured(
+        "RECAPTCHA_V3_SECRET_KEY and RECAPTCHA_V3_SITE_KEY must be provided together"
+    )
 
 # django-crispy-forms
 CRISPY_TEMPLATE_PACK = "bootstrap3"

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -1,5 +1,6 @@
-from captcha import fields
+from captcha import fields, widgets
 from django import forms
+from django.conf import settings
 
 from ..localgroups.models import LocalGroup
 from .models import Profile, validate_sluggable_name
@@ -21,7 +22,8 @@ class SignupForm(forms.Form):
     is_public = forms.BooleanField(
         required=False, label="Show my profile to the public", initial=True
     )
-    captcha = fields.ReCaptchaField(label="")
+    if hasattr(settings, "RECAPTCHA_PUBLIC_KEY"):
+        captcha = fields.ReCaptchaField(label="", widget=widgets.ReCaptchaV3)
 
     field_order = ["name", "email", "password1", "password2", "is_public", "captcha"]
 

--- a/eahub/templates/account/signup.html
+++ b/eahub/templates/account/signup.html
@@ -10,13 +10,6 @@
 
 {% endblock %}
 
-<div class="field">
-  <div class="g-recaptcha" data-sitekey="{{ recaptcha_site_key }}"></div>
-  {% if 'captcha_error' in request.GET %}
-    <div class="alert alert-danger login-danger" style="max-width: 304px;">Captcha error</div>
-  {% endif %}
-</div>
-
 {% block submit%}Sign up{% endblock%}
 
 {% block form_privacy_note %}
@@ -24,7 +17,10 @@
 <br>
 
 <div class="privacy-note">
-  Read more about our approach to privacy in our <a href="{% url 'privacy_policy' %}">Privacy Policy</a>.
+  <p>This site is protected by reCAPTCHA and the Google
+    <a href="https://policies.google.com/privacy">Privacy Policy</a> and
+    <a href="https://policies.google.com/terms">Terms of Service</a> apply.</p>
+  <p>Read more about our approach to privacy in our <a href="{% url 'privacy_policy' %}">Privacy Policy</a>.</p>
 </div>
 
 {% endblock %}

--- a/eahub/tests/signup_test.py
+++ b/eahub/tests/signup_test.py
@@ -3,7 +3,6 @@ import time
 import pytest
 from django.test import override_settings
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 
 
 @override_settings(
@@ -35,12 +34,6 @@ def test_signup_success(driver, live_server):
 
     # "Visible to public" unchecked
     driver.find_element(By.CSS_SELECTOR, public).click()
-
-    # Recaptcha solved
-    driver.find_element(By.CSS_SELECTOR, password_field_2).send_keys(
-        Keys.TAB + Keys.TAB + Keys.SPACE
-    )
-    time.sleep(5)
 
     # Then:
     # Submit


### PR DESCRIPTION
The threshold is currently set at 85%; we can adjust it up or down later if need be.

This involves creating a new site in the reCAPTCHA admin console; I currently own it.

The site key is in a separate setting from the v2 one, which I've already created in production, so we can switch back and forth with just code deployments if need be.

By default, reCAPTCHA is disabled in local development, but you can enable it by signing up for a site on localhost and adding your keys to your .env file.

I don't know how much this will help, but it may be worth a try.