### PR TITLE
Improve admin user list for easier mass approval

### DIFF
--- a/eahub/base/admin.py
+++ b/eahub/base/admin.py
@@ -1,19 +1,45 @@
+import django_admin_relation_links
 from authtools import admin as authtools_admin
 from django.contrib import admin
 
+from ..profiles import models as profiles_models
 from . import models
 
 
 @admin.register(models.User)
-class UserAdmin(authtools_admin.UserAdmin):
+class UserAdmin(
+    django_admin_relation_links.AdminChangeLinksMixin, authtools_admin.UserAdmin
+):
+    list_select_related = ["profile"]
     list_display = [
         "is_active",
         "email",
-        "profile",
+        "profile_link",
+        "is_profile_approved",
+        "date_joined",
         "is_superuser",
         "is_staff",
-        "date_joined",
     ]
-    list_display_links = ["email", "profile"]
+    change_links = ["profile"]
+    list_filter = ["is_superuser", "is_staff", "is_active", "profile__is_approved"]
     search_fields = ["email", "profile__name"]
     ordering = ["-date_joined"]
+    actions = ["approve_profiles"]
+
+    def is_profile_approved(self, user):
+        try:
+            profile = user.profile
+        except profiles_models.Profile.DoesNotExist:
+            return None
+        return profile.is_approved
+
+    is_profile_approved.short_description = "Approved?"
+    is_profile_approved.boolean = True
+
+    def approve_profiles(self, request, queryset):
+        profiles_models.Profile.objects.filter(user__in=queryset).update(
+            is_approved=True
+        )
+
+    approve_profiles.short_description = "Approve selected users' profiles"
+    approve_profiles.allowed_permissions = ["change"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,3 +41,4 @@ pep8-naming==0.8.2
 isort[requirements]==4.3.20
 flake8-isort==2.7.0
 django-webpack-loader==0.6.0
+django-admin-relation-links==0.2.4


### PR DESCRIPTION
You can now:
-   See right away whether a user's profile is approved.
-   Filter for only users with approved or unapproved profiles.
-   Click a user's name to see their profile in the admin.
-   Check multiple users and approve them all at once.

It should also be faster now with fewer redundant database queries.