### PR TITLE
Remove echo statement to actually run collectstatic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG buildfolder=/static_build
 ENV buildfolder=${buildfolder}
 COPY --from=frontend	/eahub/base/static $buildfolder
 RUN	mkdir /static \
-	&& if [ "${buildfolder}" = "/static_build" ]; then echo DJANGO_SETTINGS_MODULE=eahub.config.build_settings django-admin collectstatic; \
+	&& if [ "${buildfolder}" = "/static_build" ]; then DJANGO_SETTINGS_MODULE=eahub.config.build_settings django-admin collectstatic; \
 	else DJANGO_SETTINGS_MODULE=eahub.config.build_settings_dev django-admin collectstatic; \
 	fi;
 ENV	DJANGO_SETTINGS_MODULE	eahub.config.settings


### PR DESCRIPTION
As discovered in the video conference with @michaltrzesimiech, @taymonbeal and @victor-yunenko, the error concerning webpack and collectstatic was caused by a misplaced ```echo``` statement in the ```Dockerfile```. I know that the plan was to re-implement our webpack solution, but I don't think anyone is currently working on this. I thus suggest that we for now just remove the ```echo``` to have a temporary fix. This is what this PR is for.

Not doing this would block any further development as the pipeline fails due to this error. While the current implementation is not the most elegant, I don't think we should wait for a new implementation, of which we don't know when it might come. 