### PR TITLE
Fix bug throwing 500 on edit profile community

### DIFF
--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -119,11 +119,7 @@ class EditProfileCommunityForm(forms.ModelForm):
 
     class Meta:
         model = Profile
-        fields = (
-            "available_as_speaker",
-            "topics_i_speak_about",
-            "local_groups",
-        )
+        fields = ("available_as_speaker", "topics_i_speak_about", "local_groups")
         widgets = {
             "topics_i_speak_about": forms.Textarea(attrs={"rows": 3, "maxlength": 2000})
         }

--- a/eahub/profiles/forms.py
+++ b/eahub/profiles/forms.py
@@ -123,7 +123,6 @@ class EditProfileCommunityForm(forms.ModelForm):
             "available_as_speaker",
             "topics_i_speak_about",
             "local_groups",
-            "email_visible",
         )
         widgets = {
             "topics_i_speak_about": forms.Textarea(attrs={"rows": 3, "maxlength": 2000})

--- a/eahub/templates/eahub/edit_profile_community.html
+++ b/eahub/templates/eahub/edit_profile_community.html
@@ -28,10 +28,6 @@
 {{ form.topics_i_speak_about|as_crispy_field }}
 </div>
 
-<div class="field">
-{{ form.public_email|as_crispy_field }}
-</div>
-
 {% endblock %}
 
 {% block submit%}Update{% endblock%}


### PR DESCRIPTION
Fixes a bug that throw a 500 whenever user went on the edit community page on their profile. Removes the "email is public" toggle from this form page, as this option already exists on the main edit profile page
