### PR TITLE
Set default for emails_visible in profile model

### DIFF
--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -281,7 +281,7 @@ class Profile(models.Model):
         enum.EnumField(ExpertiseArea), blank=True, default=list
     )
     available_as_speaker = models.BooleanField(null=True, blank=True, default=None)
-    email_visible = models.BooleanField()
+    email_visible = models.BooleanField(default=False)
     topics_i_speak_about = models.TextField(
         blank=True, validators=[MaxLengthValidator(2000)]
     )


### PR DESCRIPTION
to allign with migration file. Otherwise, when running "migrate", it is suggested that there are changes in the model not reflected in migration files.