### PR TITLE
931 email notifications on edits

### DIFF
--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -41,7 +41,7 @@ class LocalGroupCreateView(
     def form_valid(self, form):
         form.instance.geocode()
         print(self.kwargs)
-        send_mail_on_change(self.request, form.cleaned_data["name"], "create_group.txt")
+        send_mail_on_change(self.request, "create_group.txt", form.cleaned_data["name"], )
         return super().form_valid(form)
 
 
@@ -63,7 +63,7 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
     def form_valid(self, form):
         if "city_or_town" in form.changed_data or "country" in form.changed_data:
             form.instance.geocode()
-        send_mail_on_change(self.request, form.cleaned_data["name"], "update_group.txt", self.kwargs["slug"])
+        send_mail_on_change(self.request, "update_group.txt", form.cleaned_data["name"], self.kwargs["slug"])
 
         return super().form_valid(form)
 
@@ -75,7 +75,7 @@ class LocalGroupDeleteView(rules_views.PermissionRequiredMixin, edit_views.Delet
     permission_required = "localgroups.delete_local_group"
 
     def form_valid(self, form):
-        send_mail_on_change(self.request, form.cleaned_data["name"], "delete_group.txt", self.kwargs["slug"])
+        send_mail_on_change(self.request, "delete_group.txt", form.cleaned_data["name"], self.kwargs["slug"])
         return super().form_valid(form)
 
 

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -43,7 +43,9 @@ class LocalGroupCreateView(
     def form_valid(self, form):
         form.instance.geocode()
         self.object = form.save()
-        send_mail_on_change(self.request, "create_group.txt", self.object.name, self.object.slug)
+        send_mail_on_change(
+            self.request, "create_group.txt", self.object.name, self.object.slug
+        )
         return super().form_valid(form)
 
 
@@ -67,7 +69,9 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
             form.instance.geocode()
         old_name = self.object.name
         self.object = form.save()
-        send_mail_on_change(self.request, "update_group.txt", old_name, self.object.slug)
+        send_mail_on_change(
+            self.request, "update_group.txt", old_name, self.object.slug
+        )
         return super().form_valid(form)
 
 
@@ -167,6 +171,7 @@ def report_group_inactive(request, slug):
     )
     return redirect("/group/{}".format(group.slug))
 
+
 @login_required
 @require_POST
 def send_mail_on_change(request, template, name, slug):
@@ -196,8 +201,8 @@ def send_mail_on_change(request, template, name, slug):
             "group_name": name,
             "group_url": "https://{0}/group/{1}".format(
                 get_current_site(request).domain, slug
-            )
-        }
+            ),
+        },
     )
     recipient_list = [email for email in settings.LEAN_MANAGERS]
     recipient_list.append(settings.GROUPS_EMAIL)

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -65,12 +65,11 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
     def form_valid(self, form):
         if "city_or_town" in form.changed_data or "country" in form.changed_data:
             form.instance.geocode()
+        old_name = self.object.name
+        self.object = form.save()
+        send_mail_on_change(self.request, "update_group.txt", old_name, self.object.slug)
+        return super().form_valid(form)
 
-        res = super().form_valid(form)
-
-        send_mail_on_change(self.request, "update_group.txt", res.status_code, self.kwargs["slug"])
-
-        return res
 
 
 class LocalGroupDeleteView(rules_views.PermissionRequiredMixin, edit_views.DeleteView):

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -17,8 +17,6 @@ from ..profiles.models import Profile
 from .forms import LocalGroupForm
 from .models import LocalGroup
 
-import logging
-
 
 class LocalGroupCreateView(
     auth_mixins.LoginRequiredMixin,

--- a/eahub/templates/emails/create_group.txt
+++ b/eahub/templates/emails/create_group.txt
@@ -1,0 +1,5 @@
+Dear Admin,
+
+User {{user_name}} ({{user_eahub_url}}) has created group {{group_name}}.
+
+This email has been automatically generated.

--- a/eahub/templates/emails/create_group.txt
+++ b/eahub/templates/emails/create_group.txt
@@ -1,5 +1,5 @@
 Dear Admin,
 
-User {{user_name}} ({{user_eahub_url}}) has created group {{group_name}}.
+User {{user_name}} ({{user_eahub_url}}) has created group {{group_name}} ({{group_url}}).
 
 This email has been automatically generated.

--- a/eahub/templates/emails/delete_group.txt
+++ b/eahub/templates/emails/delete_group.txt
@@ -1,0 +1,5 @@
+Dear Admin,
+
+User {{user_name}} ({{user_eahub_url}}) has deleted group {{group_name}} ({{group_url}}).
+
+This email has been automatically generated.

--- a/eahub/templates/emails/update_group.txt
+++ b/eahub/templates/emails/update_group.txt
@@ -1,0 +1,5 @@
+Dear Admin,
+
+User {{user_name}} ({{user_eahub_url}}) has updated group {{group_name}}. Check the group's page ({{group_url}}) to see more details.
+
+This email has been automatically generated.


### PR DESCRIPTION
Sends emails to groups@effectivealtruism.org and lean@eahub.org on the following actions:
- Group is created  
- Group is updated
- Group is deleted

The emails look as follows (emails addresses are dummy emails, not real ones):
![image](https://user-images.githubusercontent.com/15908208/87882715-f99bd300-c9f9-11ea-91bc-e950f4536fa0.png)
![image](https://user-images.githubusercontent.com/15908208/87882723-028ca480-c9fa-11ea-8b6c-1995d6542fcb.png)
![image](https://user-images.githubusercontent.com/15908208/87882728-1506de00-c9fa-11ea-8bc0-9df3fd3ba110.png)  

**How to QA**:
Create, update and delete a group and check whether 
  1) The actions are successful (group created, updated, deleted)  
  2) Emails received at localhost:8001
