### PR TITLE
880 add free text organiser

### DIFF
--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -1,4 +1,5 @@
 import csv
+
 from django.http import HttpResponse
 
 from ..profiles import models

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -16,8 +16,8 @@ class ExportCsvMixin:
     def export_csv(self, request, queryset, meta, ignore=[]):
         field_names = [field.name for field in meta.fields if field.name not in ignore]
 
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+        response = HttpResponse(content_type="text/csv")
+        response["Content-Disposition"] = "attachment; filename={}.csv".format(meta)
         writer = csv.writer(response)
 
         writer.writerow(field_names)

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -13,8 +13,7 @@ def user_display(user):
 
 
 class ExportCsvMixin:
-    def export_csv(self, request, queryset, ignore=[]):
-        meta = models.LocalGroup._meta
+    def export_csv(self, request, queryset, meta, ignore=[]):
         field_names = [field.name for field in meta.fields if field.name not in ignore]
 
         response = HttpResponse(content_type='text/csv')

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -23,7 +23,7 @@ class ExportCsvMixin:
 
         writer.writerow(field_names)
         for obj in queryset:
-            row = writer.writerow(obj.convert_to_row(field_names))
+            writer.writerow(obj.convert_to_row(field_names))
 
         return response
 

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -13,7 +13,7 @@ def user_display(user):
 
 
 class ExportCsvMixin:
-    def export_csv(self, request, queryset, ignore):
+    def export_csv(self, request, queryset, ignore=[]):
         meta = models.LocalGroup._meta
         field_names = [field.name for field in meta.fields if field.name not in ignore]
 

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -1,3 +1,6 @@
+import csv
+from django.http import HttpResponse
+
 from ..profiles import models
 
 
@@ -7,3 +10,21 @@ def user_display(user):
     except models.Profile.DoesNotExist:
         return user.email
     return profile.name
+
+
+class ExportCsvMixin:
+    def export_csv(self, request, queryset, ignore):
+        meta = models.LocalGroup._meta
+        field_names = [field.name for field in meta.fields if field.name not in ignore]
+
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+        writer = csv.writer(response)
+
+        writer.writerow(field_names)
+        for obj in queryset:
+            row = writer.writerow(obj.convert_to_row(field_names))
+
+        return response
+
+    export_csv.short_description = "Export as CSV"

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -3,11 +3,14 @@ from django.contrib import admin
 from . import models
 from ..base import utils
 
+
 class LocalGroupAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
-    actions = ['export_csv']
+    actions = ["export_csv"]
 
     def export_csv(self, request, queryset):
-        return utils.ExportCsvMixin.export_csv(self,request,queryset, models.LocalGroup._meta, ["local_group_type"])
+        return utils.ExportCsvMixin.export_csv(
+            self, request, queryset, models.LocalGroup._meta, ["local_group_type"]
+        )
 
 
 admin.site.register(models.LocalGroup, LocalGroupAdmin)

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -1,5 +1,28 @@
 from django.contrib import admin
 
+import csv
+from django.http import HttpResponse
+
 from . import models
 
-admin.site.register(models.LocalGroup)
+class LocalGroupAdmin(admin.ModelAdmin):
+    actions = ['export_csv']
+
+    def export_csv(self, request, queryset):
+        meta = models.LocalGroup._meta
+        field_names = [field.name for field in meta.fields if field.name != "local_group_type"]
+
+        response = HttpResponse(content_type='text/csv')
+        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
+        writer = csv.writer(response)
+
+        writer.writerow(field_names)
+        for obj in queryset:
+            row = writer.writerow(obj.convert_to_row(field_names))
+
+        return response
+
+    export_csv.short_description = "Export as CSV"
+
+
+admin.site.register(models.LocalGroup, LocalGroupAdmin)

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
-from . import models
 from ..base import utils
+from . import models
 
 
 class LocalGroupAdmin(admin.ModelAdmin, utils.ExportCsvMixin):

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -7,7 +7,7 @@ class LocalGroupAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
     actions = ['export_csv']
 
     def export_csv(self, request, queryset):
-        return utils.ExportCsvMixin.export_csv(self,request,queryset,["local_group_type"])
+        return utils.ExportCsvMixin.export_csv(self,request,queryset, models.LocalGroup._meta, ["local_group_type"])
 
 
 admin.site.register(models.LocalGroup, LocalGroupAdmin)

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -1,28 +1,13 @@
 from django.contrib import admin
 
-import csv
-from django.http import HttpResponse
-
 from . import models
+from ..base import utils
 
-class LocalGroupAdmin(admin.ModelAdmin):
+class LocalGroupAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
     actions = ['export_csv']
 
     def export_csv(self, request, queryset):
-        meta = models.LocalGroup._meta
-        field_names = [field.name for field in meta.fields if field.name != "local_group_type"]
-
-        response = HttpResponse(content_type='text/csv')
-        response['Content-Disposition'] = 'attachment; filename={}.csv'.format(meta)
-        writer = csv.writer(response)
-
-        writer.writerow(field_names)
-        for obj in queryset:
-            row = writer.writerow(obj.convert_to_row(field_names))
-
-        return response
-
-    export_csv.short_description = "Export as CSV"
+        return utils.ExportCsvMixin.export_csv(self,request,queryset,["local_group_type"])
 
 
 admin.site.register(models.LocalGroup, LocalGroupAdmin)

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -27,6 +27,7 @@ class LocalGroup(models.Model):
     organisers = models.ManyToManyField(
         settings.AUTH_USER_MODEL, through="Organisership", blank=True
     )
+    organisers_freetext = models.CharField("Organisers (Non-Member)", max_length=100, blank=True)
     local_group_type = enum.EnumField(
         LocalGroupType, null=True, blank=True, default=None
     )

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -87,6 +87,14 @@ class LocalGroup(models.Model):
         else:
             return "Other"
 
+    def convert_to_row(self, field_names):
+        values = []
+        for field in field_names:
+            if (field == 'local_group_types'):
+                values.append(self.get_local_group_types())
+            else:
+                values.append(getattr(self, field))
+        return values
 
 class Organisership(models.Model):
     local_group = models.ForeignKey(LocalGroup, on_delete=models.CASCADE)

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -90,11 +90,12 @@ class LocalGroup(models.Model):
     def convert_to_row(self, field_names):
         values = []
         for field in field_names:
-            if (field == 'local_group_types'):
+            if field == "local_group_types":
                 values.append(self.get_local_group_types())
             else:
                 values.append(getattr(self, field))
         return values
+
 
 class Organisership(models.Model):
     local_group = models.ForeignKey(LocalGroup, on_delete=models.CASCADE)

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
-from . import models
 from ..base import utils
+from . import models
 
 
 class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -3,11 +3,14 @@ from django.contrib import admin
 from . import models
 from ..base import utils
 
+
 class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
-    actions = ['export_csv']
+    actions = ["export_csv"]
 
     def export_csv(self, request, queryset):
-        return utils.ExportCsvMixin.export_csv(self,request,queryset, models.Profile._meta)
+        return utils.ExportCsvMixin.export_csv(
+            self, request, queryset, models.Profile._meta
+        )
 
 
 admin.site.register(models.Profile, ProfileAdmin)

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -7,7 +7,7 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
     actions = ['export_csv']
 
     def export_csv(self, request, queryset):
-        return utils.ExportCsvMixin.export_csv(self,request,queryset)
+        return utils.ExportCsvMixin.export_csv(self,request,queryset, models.Profile._meta)
 
 
 admin.site.register(models.Profile, ProfileAdmin)

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -1,6 +1,14 @@
 from django.contrib import admin
 
 from . import models
+from ..base import utils
 
-admin.site.register(models.Profile)
+class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
+    actions = ['export_csv']
+
+    def export_csv(self, request, queryset):
+        return utils.ExportCsvMixin.export_csv(self,request,queryset)
+
+
+admin.site.register(models.Profile, ProfileAdmin)
 admin.site.register(models.ProfileSlug)

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -462,6 +462,17 @@ class Profile(models.Model):
         ]
         return any(community_details_exist)
 
+    def convert_to_row(self, field_names):
+        values = []
+        for field in field_names:
+            if (field == 'local_groups'):
+                values.append(self.get_pretty_local_groups())
+            elif (field == 'expertise'):
+                values.append(self.get_pretty_expertise())
+            else:
+                values.append(getattr(self, field))
+        return values
+
 
 class Membership(models.Model):
     profile = models.ForeignKey(Profile, on_delete=models.CASCADE)

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -465,19 +465,19 @@ class Profile(models.Model):
     def convert_to_row(self, field_names):
         values = []
         for field in field_names:
-            if ("_other" in field):
+            if "_other" in field:
                 continue
-            elif (field == 'cause_areas'):
+            elif field == "cause_areas":
                 values.append(self.get_pretty_cause_areas())
-            elif (field == 'expertise_areas'):
+            elif field == "expertise_areas":
                 values.append(self.get_pretty_expertise())
-            elif (field == 'career_interest_areas'):
+            elif field == "career_interest_areas":
                 values.append(self.get_pretty_career_interest_areas())
-            elif (field == 'organisational_affiliations'):
+            elif field == "organisational_affiliations":
                 values.append(self.get_pretty_organisational_affiliations())
-            elif (field == 'giving_pledges'):
+            elif field == "giving_pledges":
                 values.append(self.get_pretty_giving_pledges())
-            elif (field == 'local_groups'):
+            elif field == "local_groups":
                 values.append(self.get_pretty_local_groups())
             else:
                 values.append(getattr(self, field))

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -465,10 +465,20 @@ class Profile(models.Model):
     def convert_to_row(self, field_names):
         values = []
         for field in field_names:
-            if (field == 'local_groups'):
-                values.append(self.get_pretty_local_groups())
-            elif (field == 'expertise'):
+            if ("_other" in field):
+                continue
+            elif (field == 'cause_areas'):
+                values.append(self.get_pretty_cause_areas())
+            elif (field == 'expertise_areas'):
                 values.append(self.get_pretty_expertise())
+            elif (field == 'career_interest_areas'):
+                values.append(self.get_pretty_career_interest_areas())
+            elif (field == 'organisational_affiliations'):
+                values.append(self.get_pretty_organisational_affiliations())
+            elif (field == 'giving_pledges'):
+                values.append(self.get_pretty_giving_pledges())
+            elif (field == 'local_groups'):
+                values.append(self.get_pretty_local_groups())
             else:
                 values.append(getattr(self, field))
         return values

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -80,7 +80,7 @@
         {% if group.city_or_town %}<li class="list-group-item"><b>City/Town: </b>{{ group.city_or_town }}</li>{% endif %}
         {% if group.country %}<li class="list-group-item"><b>Country: </b>{{ group.country }}</li>{% endif %}
         {% if group.public_organisers %}
-        <li class="list-group-item"><b>Organisers:</b>
+        <li class="list-group-item"><b>Organisers (Member):</b>
           {% if group.public_organisers.count == 1 %}
           <a href="{{ group.public_organisers.0.profile.get_absolute_url }}">{{ group.public_organisers.0.profile.name }}</a>
           {% else %}
@@ -91,6 +91,7 @@
           </ul>
           {% endif %}
         {% endif %}
+        {% if group.organisers_freetext %}<li class="list-group-item"><b>Organisers (Non-Member): </b>{{ group.organisers_freetext }}</li>{% endif %}
         {% if group.website %}<li class="list-group-item"><b>Website: </b><a href="{{ group.website }}" target="_blank">{{ group.website }}</a></li>{% endif %}
         {% if group.other_website %}<li class="list-group-item"><b>Other Website: </b><a href="{{ group.other_website }}" target="_blank">{{ group.other_website }}</a></li>{% endif %}
         {% if group.facebook_group %}<li class="list-group-item"><b>Facebook Group: </b><a href="{{ group.facebook_group }}" target="_blank">{{ group.facebook_group }}</a></li>{% endif %}


### PR DESCRIPTION
Closes issue #880 

- I've added a new field to the model, and on the group detail page it will show the two fields (if both populated) like below:
![organiser](https://user-images.githubusercontent.com/24226083/88298047-96ab8400-ccf8-11ea-8ad4-2bf58b04c0bf.jpg)

- As Sebastian recommended above, the option to add a non-member organiser is not available on the new group form, only from the admin panel (is this definitely what is wanted? So now non-member organisers can only be added on admin panel, but member organisers can only be added on the new group form):

![organiser3](https://user-images.githubusercontent.com/24226083/88298388-002b9280-ccf9-11ea-9b4c-4de6871ce108.jpg)

![organiser2](https://user-images.githubusercontent.com/24226083/88298306-e7bb7800-ccf8-11ea-8404-d01acc2ed404.jpg)






