### PR TITLE
1007 update navbar

### DIFF
--- a/eahub/base/static/global/js/navbar.js
+++ b/eahub/base/static/global/js/navbar.js
@@ -1,20 +1,28 @@
 export function initNavbar() {
-  const navbar = new Navbar($('#burger-btn'), $('#navbar'));
+  const navbar = new Navbar($('#navbar-toggle-icon'), $('#navbar'));
   navbar.toggleMenuOnClick();
   navbar.disappearMenuOnMovingCursorAway();
 }
 
 class Navbar {
-  constructor(burgerBtnHtmlElement, navbarHtmlElement) {
-    this.burgerBtnHtmlElement = burgerBtnHtmlElement;
+  constructor(navbarToggleIcon, navbarHtmlElement) {
+    this.navbarToggleIcon = navbarToggleIcon;
     this.navbarHtmlElement = navbarHtmlElement;
   }
 
   toggleMenuOnClick() {
     const that = this;
-    this.burgerBtnHtmlElement.click(function(e) {
-      e.stopImmediatePropagation();
-      that.navbarHtmlElement.toggle();
+    this.navbarToggleIcon.click(function(e) {
+        var classList = that.navbarToggleIcon[0].classList;
+        if (classList.contains("navbar-toggle-up")) {
+            classList.remove("navbar-toggle-up")
+            classList.add("navbar-toggle-down")
+        } else {
+            classList.remove("navbar-toggle-down")
+            classList.add("navbar-toggle-up")
+        }
+        e.stopImmediatePropagation();
+        that.navbarHtmlElement.toggle();
     })
   }
 

--- a/eahub/base/static/global/js/navbar.js
+++ b/eahub/base/static/global/js/navbar.js
@@ -1,38 +1,49 @@
 export function initNavbar() {
-  const navbar = new Navbar($('#navbar-toggle-icon'), $('#navbar'));
+  const navbar = new Navbar($('#menu-toggle-icon'), $('#burger-btn'), $('#dropdown'), $('#navbar-collapsable'));
   navbar.toggleMenuOnClick();
   navbar.disappearMenuOnMovingCursorAway();
 }
 
 class Navbar {
-  constructor(navbarToggleIcon, navbarHtmlElement) {
+  constructor(navbarToggleIcon, burgerBtn, dropdownElement, navbarCollapsable) {
     this.navbarToggleIcon = navbarToggleIcon;
-    this.navbarHtmlElement = navbarHtmlElement;
+    this.dropdownElement = dropdownElement;
+    this.burgerBtn = burgerBtn;
+    this.navbarCollapsable = navbarCollapsable;
   }
 
   toggleMenuOnClick() {
     const that = this;
-    this.navbarToggleIcon.click(function(e) {
-        var classList = that.navbarToggleIcon[0].classList;
-        if (classList.contains("navbar-toggle-up")) {
-            classList.remove("navbar-toggle-up")
-            classList.add("navbar-toggle-down")
-        } else {
-            classList.remove("navbar-toggle-down")
-            classList.add("navbar-toggle-up")
-        }
-        e.stopImmediatePropagation();
-        that.navbarHtmlElement.toggle();
-    })
+    this.navbarToggleIcon.click(function(e) {that.toggleMenu(e)})
+    this.burgerBtn.click(function(e) {that.toggleCollapsable(e)})
   }
 
   disappearMenuOnMovingCursorAway() {
-    this.navbarHtmlElement.onmouseout = function(event) {
+    this.dropdownElement.onmouseout = function(event) {
       var element_left = event.target
       var element_new = event.relatedTarget
       if (element_new.className.includes('container') || element_new.id == 'body') {
         navbar.style.display = 'none'
       }
     }
+  }
+
+  toggleMenu(e) {
+    var that = this;
+    var classList = that.navbarToggleIcon[0].classList;
+    if (classList.contains("menu-toggle-up")) {
+        classList.remove("menu-toggle-up")
+        classList.add("menu-toggle-down")
+    } else {
+        classList.remove("menu-toggle-down")
+        classList.add("menu-toggle-up")
+    }
+    e.stopImmediatePropagation();
+    that.dropdownElement.toggle();
+  }
+
+  toggleCollapsable(e) {
+    e.stopImmediatePropagation();
+    this.navbarCollapsable.toggle();
   }
 }

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -166,14 +166,20 @@ body {
 }
 
 .navbar-menu {
-  background-color: rgba(81, 43, 82, 0.9);
-  border-radius: 5px;
-  display: none;
-  float: right;
-  padding-left: 20px;
-  padding-right: 5px;
-  border-top-right-radius: 0;
-  border-top-left-radius: 0;
+  background-color: white;
+  position: absolute;
+  right: 30px;
+  left: initial;
+    z-index: 1000;
+    display: none;
+    min-width: 178px;
+    padding: .5rem 0;
+    margin: .125rem 0 0;
+    color: #333;
+    text-align: left;
+    list-style: none;
+    background-clip: padding-box;
+    border: 1px solid rgba(0,0,0,0.15);
 }
 .navbar-menu-container {
   left: 0;
@@ -197,7 +203,7 @@ body {
 }
 .navbar-nav li a {
   padding: 5px 15px 5px 0px;
-  color: white;
+  color: black;
   text-decoration: none;
 }
 .navbar-nav li:hover {
@@ -211,9 +217,7 @@ body {
 .navbar-nav {
   display: inline-block;
   float: none!important;
-  margin-right: 0px !important;
-  margin-top: 7.5px;
-  text-align: right;
+  padding: 10px 16px;
   width: 100%;
 }
 

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -151,7 +151,6 @@ body {
   margin-top: 12px;
 }
 .navbar .logo_full {
-  margin-top: 8px;
   width: 220px
 }
 .navbar .logo_with_page_name {
@@ -178,7 +177,7 @@ body {
   background-color: white;
   position: absolute;
   top: 38px;
-  right: 30px;
+  right: 0;
   left: initial;
   z-index: 1000;
   display: none;
@@ -202,7 +201,9 @@ body {
   display: block;
 }
 .navbar-nav li a {
-  padding: 10px 16px;
+  padding-left: 10px;
+  padding-top: 0px;
+  padding-bottom: 0px;
   color: black !important;
   text-decoration: none;
 }
@@ -258,13 +259,27 @@ body {
 }
 .navbar-signup-md li {
   padding: 8px 0px;
+  position: relative;
 }
 .navbar-signup-xs {
   display: none !important;
 }
 #burger-btn {
   display: none;
+  background: transparent;
+  position: absolute;
+  right: 10px;
+  top: 8px;
+}
+#burger-icon {
   float: right;
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3cpath stroke='rgba%28255,255,255,0.8%29' stroke-linecap='round' stroke-miterlimit='10' stroke-width='2' d='M4 7h22M4 15h22M4 23h22'/%3e%3c/svg%3e");
+  width: 1.5em;
+  height: 1.5em;
+  vertical-align: middle;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 100%;
 }
 #navbar-collapsable {
   display: flex;
@@ -785,6 +800,11 @@ form .alert ul {
 }
 
 /* other */
+.banner {
+  padding-bottom: 10px;
+  padding-top: 10px;
+}
+
 .btn {
   white-space: normal;
   max-width: 100%;
@@ -865,9 +885,15 @@ table td {
 }
 
 @media(max-width: 768px) {
+  body {
+    padding-top: 25px;
+  }
+  .banner h2 {
+    font-size: 24px;
+  }
+
   .navbar h4 {
     font-size: 20px;
-    margin-top: 14px;
   }
   .navbar-signup-xs {
     display: block !important;
@@ -880,10 +906,13 @@ table td {
   }
   .navbar-menu {
     position: relative;
-    margin-left: 10px
+    top: 0;
   }
   .menu-toggle {
     float: none;
+  }
+  .menu-toggle-up {
+    margin-left: -7px;
   }
   .navbar-signup-md {
     float: none;
@@ -895,6 +924,10 @@ table td {
   }
   #menu-toggle-icon {
     padding-left: 0;
+  }
+  .navbar .container {
+    flex-wrap: wrap;
+    margin-left: 0;
   }
 }
 

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -224,6 +224,34 @@ body {
   margin-top: 10px;
 }
 
+.navbar-toggle:hover {
+  background-color: transparent !important;
+}
+
+.navbar-toggle:focus {
+  background-color: transparent !important;
+}
+
+.navbar-toggle-icon-bootstrap3 {
+    background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='angle-down' class='svg-inline--fa fa-angle-down fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='%23FFFFFF' d='M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z'%3E%3C/path%3E%3C/svg%3E");
+    width: 15px;
+    height: 15px;
+    display: inline-block;
+    display: inline-block;
+    vertical-align: middle;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 100%;
+}
+
+.navbar-toggle-up {
+  transform: rotate(180deg);
+}
+
+.navbar-toggle-down {
+  transform: rotate(0);
+}
+
 .navbar-right {
   float: none !important;
 }
@@ -239,10 +267,6 @@ body {
 
 .navbar-signup-xs {
   display: none !important;
-}
-
-#burger-btn:hover {
-  background-color: #d6d2d2;
 }
 
 /* jumbotron */

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -8,6 +8,9 @@ body {
   padding-bottom: 20px;
   font-family: "Open Sans";
 }
+.container:before, .container:after  {
+  content: none;
+}
 
 /* info */
 
@@ -113,20 +116,21 @@ body {
 }
 
 /* nav */
+.brand {
+  display: flex;
+  align-items: center;
+}
 .navbar h4 {
   color: white;
   display: inline-block;
   font-size: 22px;
-  margin-top: 12px;
+  margin-top: 2px;
   padding-left: 5px;
 }
 .navbar img {
   width: 100px;
   height: auto;
   margin-bottom: 8px;
-}
-.navbar li {
-  float: none;
 }
 .navbar li a {
   padding: 5px 15px 5px 0px;
@@ -138,6 +142,10 @@ body {
 }
 .navbar .container {
   z-index: 20;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
 }
 .navbar .logo {
   margin-top: 12px;
@@ -149,10 +157,13 @@ body {
 .navbar .logo_with_page_name {
   margin-top: 0px;
 }
-
 .navbar-header {
   background-color: #7bb0a8;
-  float: none;
+  display: flex;
+  flex-wrap: nowrap;
+  justify-content: flex-start;
+  width: 100%;
+  padding-top: 4px;
 }
 .navbar-inverse {
   background-color: transparent;
@@ -163,108 +174,102 @@ body {
 .navbar-inverse{
   border: none;
 }
-
 .navbar-menu {
   background-color: white;
   position: absolute;
+  top: 38px;
   right: 30px;
   left: initial;
-    z-index: 1000;
-    display: none;
-    min-width: 178px;
-    padding: .5rem 0;
-    margin: .125rem 0 0;
-    color: #333;
-    text-align: left;
-    list-style: none;
-    background-clip: padding-box;
-    border: 1px solid rgba(0,0,0,0.15);
+  z-index: 1000;
+  display: none;
+  min-width: 178px;
+  padding: .5rem 0;
+  margin: .125rem 0 0;
+  color: #333;
+  text-align: left;
+  list-style: none;
+  background-clip: padding-box;
+  border: 1px solid rgba(0,0,0,0.15);
 }
-.navbar-menu-container {
-  left: 0;
-  right: 0;
-  margin-left: auto;
-  margin-right: auto;
-  position: fixed;
-  padding: 0;
-  z-index: 100;
+.navbar-menu li {
+  float: none;
 }
 .navbar-nav a {
   margin-right: -5px;
 }
-
 .navbar-nav ul {
   margin-left: 10px;
   display: block;
 }
-.navbar-nav li {
-  float: none;
-}
 .navbar-nav li a {
   padding: 10px 16px;
-  color: black;
+  color: black !important;
   text-decoration: none;
 }
 .navbar-nav li a:hover {
   background-color: #d6d6d6
 }
-
 .navbar-nav {
   display: inline-block;
   float: none!important;
   width: 100%;
+  margin: 0;
 }
-
-.navbar-toggle {
+#menu-toggle-icon {
+  background-color: transparent;
+}
+.menu-toggle {
   border: none;
   display: inline-block;
-  float: right !important;
-  margin-top: 10px;
+  float: right;
 }
-
-.navbar-toggle:hover {
+.menu-toggle:hover {
   background-color: transparent !important;
 }
-
-.navbar-toggle:focus {
+.menu-toggle:focus {
   background-color: transparent !important;
 }
-
-.navbar-toggle-icon-bootstrap3 {
+.menu-toggle-icon-bootstrap3 {
     background-image: url("data:image/svg+xml,%3Csvg aria-hidden='true' focusable='false' data-prefix='fas' data-icon='angle-down' class='svg-inline--fa fa-angle-down fa-w-10' role='img' xmlns='http://www.w3.org/2000/svg' viewBox='0 0 320 512'%3E%3Cpath fill='%23FFFFFF' d='M143 352.3L7 216.3c-9.4-9.4-9.4-24.6 0-33.9l22.6-22.6c9.4-9.4 24.6-9.4 33.9 0l96.4 96.4 96.4-96.4c9.4-9.4 24.6-9.4 33.9 0l22.6 22.6c9.4 9.4 9.4 24.6 0 33.9l-136 136c-9.2 9.4-24.4 9.4-33.8 0z'%3E%3C/path%3E%3C/svg%3E");
     width: 15px;
     height: 15px;
-    display: inline-block;
     display: inline-block;
     vertical-align: middle;
     background-repeat: no-repeat;
     background-position: center;
     background-size: 100%;
 }
-
-.navbar-toggle-up {
+.menu-toggle-up {
   transform: rotate(180deg);
 }
-
-.navbar-toggle-down {
+.menu-toggle-down {
   transform: rotate(0);
 }
-
 .navbar-right {
   float: none !important;
 }
 .navbar-signup-md {
-  display: inline-block;
-  float: right;
-  margin-right: 0px;
-  margin-top: 17px;
+  display: flex;
+  margin-left: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  flex-direction: row;
+  list-style: none;
 }
 .navbar-signup-md li {
-  display: inline-block;
+  padding: 8px 0px;
 }
-
 .navbar-signup-xs {
   display: none !important;
+}
+#burger-btn {
+  display: none;
+  float: right;
+}
+#navbar-collapsable {
+  display: flex;
+  align-items: center;
+  width: 100%;
 }
 
 /* jumbotron */
@@ -864,13 +869,32 @@ table td {
     font-size: 20px;
     margin-top: 14px;
   }
-
-  .navbar-signup-md {
-    display: none;
-  }
-
   .navbar-signup-xs {
     display: block !important;
+  }
+  #burger-btn {
+    display: inline-block;
+  }
+  #navbar-collapsable {
+    display: none;
+  }
+  .navbar-menu {
+    position: relative;
+    margin-left: 10px
+  }
+  .menu-toggle {
+    float: none;
+  }
+  .navbar-signup-md {
+    float: none;
+    display: block;
+    padding-left: 0;
+  }
+  .navbar-signup-md li {
+    display: block;
+  }
+  #menu-toggle-icon {
+    padding-left: 0;
   }
 }
 

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -128,14 +128,13 @@ body {
 .navbar li {
   float: none;
 }
-.navbar li:hover {
-  transform: scale(1.1);
-  font-weight: 500;
-}
 .navbar li a {
   padding: 5px 15px 5px 0px;
   color: white;
   text-decoration: none;
+}
+.navbar li a:hover {
+  color: #e4efee;
 }
 .navbar .container {
   z-index: 20;
@@ -202,22 +201,17 @@ body {
   float: none;
 }
 .navbar-nav li a {
-  padding: 5px 15px 5px 0px;
+  padding: 10px 16px;
   color: black;
   text-decoration: none;
 }
-.navbar-nav li:hover {
-  transform: scale(1.1);
-  font-weight: 500;
-}
-.navbar-nav a:hover {
-  background-color: inherit !important;
+.navbar-nav li a:hover {
+  background-color: #d6d6d6
 }
 
 .navbar-nav {
   display: inline-block;
   float: none!important;
-  padding: 10px 16px;
   width: 100%;
 }
 

--- a/eahub/base/static/global/styles/main.css
+++ b/eahub/base/static/global/styles/main.css
@@ -120,6 +120,12 @@ body {
   display: flex;
   align-items: center;
 }
+.navbar {
+  padding-top: 8px;
+  padding-bottom: 8px;
+  height: 36px;
+  background-color: #7bb0a8 !important;
+}
 .navbar h4 {
   color: white;
   display: inline-block;
@@ -148,13 +154,10 @@ body {
   align-items: center;
 }
 .navbar .logo {
-  margin-top: 12px;
+  margin-top: 0px;
 }
 .navbar .logo_full {
   width: 220px
-}
-.navbar .logo_with_page_name {
-  margin-top: 0px;
 }
 .navbar-header {
   background-color: #7bb0a8;
@@ -176,7 +179,7 @@ body {
 .navbar-menu {
   background-color: white;
   position: absolute;
-  top: 38px;
+  top: 34px;
   right: 0;
   left: initial;
   z-index: 1000;
@@ -258,7 +261,7 @@ body {
   list-style: none;
 }
 .navbar-signup-md li {
-  padding: 8px 0px;
+  padding: 4px 0px 8px;
   position: relative;
 }
 .navbar-signup-xs {
@@ -269,7 +272,7 @@ body {
   background: transparent;
   position: absolute;
   right: 10px;
-  top: 8px;
+  top: 14px;
 }
 #burger-icon {
   float: right;
@@ -921,6 +924,7 @@ table td {
   }
   .navbar-signup-md li {
     display: block;
+    padding-top: 8px 0px;
   }
   #menu-toggle-icon {
     padding-left: 0;

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -51,48 +51,56 @@
     <nav class="navbar navbar-inverse navbar-fixed-top">
         <div class="navbar-header">
           <div class="container">
-          <button type="button" id="navbar-toggle-icon" class="navbar-toggle navbar-toggle-down">
-            <span class="navbar-toggle-icon-bootstrap3"></span>
-          </button>
-          <ul class="navbar-signup-md">
-            {% if user.is_authenticated %}
-              <li><a href="{% url 'my_profile' %}"><i class="fa fa-user"></i> My Profile</a></li>
+            <div class="brand">
+            {% if page_name in 'Profiles,Groups,Speakers,Candidates,Volunteers' %}
+              <a href="/"><img class="logo_with_page_name" id="logo" src="/static/global/images/logo_transparent.png" /></a>
+              <h4> /{{ page_name }}</h4>
+            {% elif page_name == 'Home' %}
+              <a href="/"><img class="logo_full" id="logo" src="/static/global/images/logo_full_transparent.png" /></a>
             {% else %}
-            {% if 'groups.eahub.org' not in request.build_absolute_uri %}
-              <li><a href="{% url 'account_login' %}?next={% firstof request.path '/' %}" id="navbar_login" ><i class="fa fa-sign-in-alt"></i> Log In</a></li>
-              <li><a href="{% url 'account_signup' %}" id="navbar_signup"><i class="fa fa-user-plus"></i> Sign Up</a></li>
+              <a href="/"><img class="logo" id="logo" src="/static/global/images/logo_transparent.png" /></a>
             {% endif %}
-            {% endif %}
-            {% if page_name == 'Groups' %}
-              <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
-            {% endif %}
-          </ul>
+            </div>
+          <button type="button" id="burger-btn" class="menu-toggle">
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+            <span class="icon-bar"></span>
+          </button>
+          <div id="navbar-collapsable">
+            <ul class="navbar-signup-md">
+              {% if user.is_authenticated %}
+                <li><a href="{% url 'my_profile' %}"><i class="fa fa-user"></i> My Profile</a></li>
+              {% else %}
+              {% if 'groups.eahub.org' not in request.build_absolute_uri %}
+                <li><a href="{% url 'account_login' %}?next={% firstof request.path '/' %}" id="navbar_login" ><i class="fa fa-sign-in-alt"></i> Log In</a></li>
+                <li><a href="{% url 'account_signup' %}" id="navbar_signup"><i class="fa fa-user-plus"></i> Sign Up</a></li>
+              {% endif %}
+              {% endif %}
+              {% if page_name == 'Groups' %}
+                <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
+              {% endif %}
+              <li>
+                <button type="button" id="menu-toggle-icon" class="menu-toggle menu-toggle-down">
+                  <span class="menu-toggle-icon-bootstrap3"></span>
+                </button>
+                  <div id="dropdown" class="navbar-menu">
+                    <ul class="nav navbar-nav navbar-right">
+                      <li><a name="navbar_link" id="navbar_resources" href="https://resources.eahub.org/"><i class="fa fa-book"></i> EA Resources</a></li>
+                      <li><a name="navbar_link" id="navbar_donation_swap" href="https://donationswap.eahub.org/"><i class="fa fa-exchange-alt"></i> EA Donation Swap</a></li>
+                      <li><a name="navbar_link" id="navbar_about" href="{% url 'about' %}"><i class="fa fa-info"></i> About</a></li>
+                      <li><a name="navbar_link" id="navbar_feedback" target="_blank" href="https://feedback.eahub.org"><i class="fa fa-comment"></i> Feedback</a></li>
+                      {% if user.is_authenticated %}
+                        <li class="list-more-item"><a name="navbar_link" href="{% url 'account_logout' %}?next={% firstof request.path '/' %}"><i class="fa fa-sign-out-alt" id="logout"></i> Log out</a></li>
+                      {% endif %}
+                    </ul>
+                  </div>
+              </li>
+            </ul>
 
-          {% if page_name in 'Profiles,Groups,Speakers,Candidates,Volunteers' %}
-            <a href="/"><img class="logo_with_page_name" id="logo" src="/static/global/images/logo_transparent.png" /></a>
-            <h4> / {{ page_name }}</h4>
-          {% elif page_name == 'Home' %}
-            <a href="/"><img class="logo_full" id="logo" src="/static/global/images/logo_full_transparent.png" /></a>
-          {% else %}
-            <a href="/"><img class="logo" id="logo" src="/static/global/images/logo_transparent.png" /></a>
-          {% endif %}
-
+          </div>
           </div>
         </div>
     </nav>
-     <div class="container navbar-menu-container">
-      <div id="navbar" class="navbar-menu">
-        <ul class="nav navbar-nav navbar-right">
-          <li><a name="navbar_link" id="navbar_resources" href="https://resources.eahub.org/"><i class="fa fa-book"></i> EA Resources</a></li>
-          <li><a name="navbar_link" id="navbar_donation_swap" href="https://donationswap.eahub.org/"><i class="fa fa-exchange-alt"></i> EA Donation Swap</a></li>
-          <li><a name="navbar_link" id="navbar_about" href="{% url 'about' %}"><i class="fa fa-info"></i> About</a></li>
-          <li><a name="navbar_link" id="navbar_feedback" target="_blank" href="https://feedback.eahub.org"><i class="fa fa-comment"></i> Feedback</a></li>
-          {% if user.is_authenticated %}
-            <li class="list-more-item"><a name="navbar_link" href="{% url 'account_logout' %}?next={% firstof request.path '/' %}"><i class="fa fa-sign-out-alt" id="logout"></i> Log out</a></li>
-          {% endif %}
-        </ul>
-      </div>
-    </div>
     {% block content %}{% endblock %}
     <footer class="footer">
       <div class="container">

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -62,9 +62,7 @@
             {% endif %}
             </div>
           <button type="button" id="burger-btn" class="menu-toggle">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+            <span id="burger-icon"></span>
           </button>
           <div id="navbar-collapsable">
             <ul class="navbar-signup-md">

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -51,10 +51,8 @@
     <nav class="navbar navbar-inverse navbar-fixed-top">
         <div class="navbar-header">
           <div class="container">
-          <button type="button" id="burger-btn" class="navbar-toggle">
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
-            <span class="icon-bar"></span>
+          <button type="button" id="navbar-toggle-icon" class="navbar-toggle navbar-toggle-down">
+            <span class="navbar-toggle-icon-bootstrap3"></span>
           </button>
           <ul class="navbar-signup-md">
             {% if user.is_authenticated %}

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -63,6 +63,9 @@
               <li><a href="{% url 'account_signup' %}" id="navbar_signup"><i class="fa fa-user-plus"></i> Sign Up</a></li>
             {% endif %}
             {% endif %}
+            {% if page_name == 'Groups' %}
+              <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
+            {% endif %}
           </ul>
 
           {% if page_name in 'Profiles,Groups,Speakers,Candidates,Volunteers' %}
@@ -80,18 +83,6 @@
      <div class="container navbar-menu-container">
       <div id="navbar" class="navbar-menu">
         <ul class="nav navbar-nav navbar-right">
-          {% if user.is_authenticated %}
-            <li class="navbar-signup-xs"><a name="navbar_link" id="button_myprofile" href="{% url 'my_profile' %}"><i class="fa fa-user"></i> My Profile</a></li>
-          {% else %}
-          {% if 'groups.eahub.org' not in request.build_absolute_uri %}
-            <li><a name="navbar_link" id="navbar_login" href="{% url 'account_login' %}?next={% firstof request.path '/' %}"><i class="fa fa-sign-in-alt"></i> Log In</a></li>
-            <li><a name="navbar_link" id="navbar_signup" href="{% url 'account_signup' %}"><i class="fa fa-user-plus"></i> Sign Up</a></li>
-          {% endif %}
-          {% endif %}
-          {% if 'groups.eahub.org' not in request.build_absolute_uri %}
-          <li><a name="navbar_link" id="navbar_profiles" href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
-          {% endif %}
-          <li><a name="navbar_link" id="navbar_groups" href="{% url 'groups' %}"><i class="fa fa-globe"></i> Groups</a></li>
           <li><a name="navbar_link" id="navbar_resources" href="https://resources.eahub.org/"><i class="fa fa-book"></i> EA Resources</a></li>
           <li><a name="navbar_link" id="navbar_donation_swap" href="https://donationswap.eahub.org/"><i class="fa fa-exchange-alt"></i> EA Donation Swap</a></li>
           <li><a name="navbar_link" id="navbar_about" href="{% url 'about' %}"><i class="fa fa-info"></i> About</a></li>

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -77,6 +77,9 @@
               {% if page_name == 'Groups' %}
                 <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
               {% endif %}
+              {% if page_name == 'Profiles' %}
+                <li><a href="{% url 'groups' %}"><i class="fa fa-globe"></i> Groups</a></li>
+              {% endif %}
               <li>
                 <button type="button" id="menu-toggle-icon" class="menu-toggle menu-toggle-down">
                   <span class="menu-toggle-icon-bootstrap3"></span>

--- a/eahub/templates/base.html
+++ b/eahub/templates/base.html
@@ -66,19 +66,17 @@
           </button>
           <div id="navbar-collapsable">
             <ul class="navbar-signup-md">
-              {% if user.is_authenticated %}
+              {% if user.is_authenticated and request.path != "/profile/" and request.path != "/profile/first_visit/" %}
                 <li><a href="{% url 'my_profile' %}"><i class="fa fa-user"></i> My Profile</a></li>
-              {% else %}
-              {% if 'groups.eahub.org' not in request.build_absolute_uri %}
+              {% elif not user.is_authenticated %}
                 <li><a href="{% url 'account_login' %}?next={% firstof request.path '/' %}" id="navbar_login" ><i class="fa fa-sign-in-alt"></i> Log In</a></li>
                 <li><a href="{% url 'account_signup' %}" id="navbar_signup"><i class="fa fa-user-plus"></i> Sign Up</a></li>
               {% endif %}
-              {% endif %}
-              {% if page_name == 'Groups' %}
-                <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
-              {% endif %}
-              {% if page_name == 'Profiles' %}
+              {% if page_name != 'Groups' %}
                 <li><a href="{% url 'groups' %}"><i class="fa fa-globe"></i> Groups</a></li>
+              {% endif %}
+              {% if page_name != 'Profiles' %}
+                <li><a href="{% url 'profiles' %}"><i class="fa fa-users"></i> Profiles</a></li>
               {% endif %}
               <li>
                 <button type="button" id="menu-toggle-icon" class="menu-toggle menu-toggle-down">

--- a/eahub/templates/eahub/index.html
+++ b/eahub/templates/eahub/index.html
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-<div class="jumbotron">
+<div class="jumbotron banner">
   <div class="container">
     <img class="hidden-xs" src="/static/global/images/banner.png">
     <h2 class="text-center">Join effective altruists around the world</h2>


### PR DESCRIPTION
* Changes the style of the existing navbar to look as much as possible as the one on the new profiles page: https://eahub-stage.us.aldryn.io/profiles/. 
* It wasn't possible to use the same code as the one on the new profiles page as this is using bootstrap 5, but we're using bootstrap 3 on all other, "old" pages. As it's not the same code, the styles aren't identical, but just similar. To achieve identical styles would have taken a lot more time, and I don't think it's worth the effort.  
* This MR is a hack to make the UX not too inconsistent between new profiles page and the other pages, but we should implement the same navbar on all pages, implying that we should replace bootstrap 3 with 5  
* When testing mobile/desktop, make sure to refresh after switching back and force between mobile and desktop on the inspector.