### PR TITLE
989 group data import fix

### DIFF
--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -143,7 +143,7 @@ class LocalGroupResource(ModelResource):
 
 @admin.register(LocalGroup)
 class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
-    actions = ["export_csv", "make_not_public"]
+    actions = ["export_csv", "make_public", "make_not_public"]
     list_display = [
         "name",
         "local_group_type",
@@ -186,6 +186,11 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
         fieldnames.append("organisers_emails")
         return ExportCsvMixin.export_csv(
             self, request, queryset, fieldnames, "localgroups"
+        )
+
+    def make_public(self, request, queryset, **kwargs):
+        queryset.update(
+            is_public=True
         )
 
     def make_not_public(self, request, queryset, **kwargs):

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -78,7 +78,7 @@ class LocalGroupResource(ModelResource):
         raise_errors=False,
         **kwargs,
     ):
-        row = self.remove_chars_from_row_keys(row, "\ufeff")
+        row = self.remove_bom_from_row_keys(row)
         return super().import_row(
             row, instance_loader, using_transactions, dry_run, raise_errors, **kwargs
         )
@@ -146,11 +146,12 @@ class LocalGroupResource(ModelResource):
 
         return (users, non_users)
 
-    def remove_chars_from_row_keys(self, row, chars):
+    def remove_bom_from_row_keys(self, row):
         new_row = {}
+        bom = "\ufeff"
         for key in row:
             if chars in key:
-                new_key = key.replace(chars, "")
+                new_key = key.replace(bom, "")
                 new_row[new_key] = row[key]
             else:
                 new_row[key] = row[key]

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -1,14 +1,36 @@
 from typing import List, Optional
 
 from django.contrib import admin
+from django.contrib.postgres.fields import ArrayField
 from import_export import fields
 from import_export.admin import ImportExportMixin
 from import_export.resources import ModelResource
 from import_export.widgets import ManyToManyWidget
+from import_export import widgets
 
 from eahub.base.models import User
 from eahub.base.utils import ExportCsvMixin
 from eahub.localgroups.models import LocalGroup, LocalGroupType
+
+import ipdb;
+
+class EnumArrayWidget(widgets.Widget):
+    """
+    Widget for an Array field. Can be used for Postgres' Array field.
+    :param separator: Defaults to ``','``
+    """
+
+    def __init__(self, separator=None):
+        if separator is None:
+            separator = ','
+        self.separator = separator
+        super().__init__()
+
+    def clean(self, value, row=None, *args, **kwargs):
+        return value
+
+    def render(self, value, obj=None):
+        return self.separator.join(str(v) for v in value)
 
 
 class LocalGroupResource(ModelResource):
@@ -29,7 +51,6 @@ class LocalGroupResource(ModelResource):
             "organisers",
             "organisers_freetext",
             "email",
-            "local_group_type_dehydrated",
             "local_group_types_dehydrated",
             "city_or_town",
             "country",
@@ -45,8 +66,14 @@ class LocalGroupResource(ModelResource):
             "other_info",
         ]
 
+    @classmethod
+    def widget_from_django_field(cls, f, default=widgets.Widget):
+        if isinstance(f, ArrayField):
+            return EnumArrayWidget
+        else:
+            return super().widget_from_django_field(f)
+
     def before_import_row(self, row: dict, **kwargs) -> dict:
-        row["local_group_type"] = self.hydrate_local_group_type(row["type"])
         row["local_group_types"] = self.hydrate_local_group_types(row["types"])
         return super().before_import_row(row, **kwargs)
 
@@ -72,8 +99,9 @@ class LocalGroupResource(ModelResource):
         self, group_types_raw: str
     ) -> Optional[List[LocalGroupType]]:
         group_types = []
-        for group_type_raw in group_types_raw:
+        for group_type_raw in group_types_raw.split(","):
             group_types.append(self.hydrate_local_group_type(group_type_raw))
+
         return group_types if group_types else None
 
 
@@ -122,3 +150,5 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
         return ExportCsvMixin.export_csv(
             self, request, queryset, fieldnames, "localgroups"
         )
+
+

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -70,7 +70,7 @@ class LocalGroupResource(ModelResource):
             return super().widget_from_django_field(f)
 
     def before_import_row(self, row: dict, **kwargs) -> dict:
-        row["local_group_types"] = self.hydrate_local_group_types(row["types"])
+        row["local_group_types"] = [type for type in self.hydrate_local_group_types(row["types"]) if type is not None]
         organisers_users, organisers_non_users = self.hydrate_organisers((row["organisers_names"]))
         row["organisers"] = ",".join(map(lambda x: str(x.id), organisers_users))
         row["organisers_freetext"] = ",".join(organisers_non_users)

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -14,6 +14,8 @@ from eahub.base.utils import ExportCsvMixin
 from eahub.localgroups.models import LocalGroup, LocalGroupType, Organisership
 from eahub.profiles.models import Profile
 
+from rangefilter.filter import DateRangeFilter
+
 class EnumArrayWidget(widgets.Widget):
     """
     Widget for an Array field. Can be used for Postgres' Array field.
@@ -150,7 +152,7 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
         "city_or_town",
         "country",
         "email",
-        "last_edited",
+        "last_edited"
     ]
     list_filter = [
         "is_public",
@@ -159,6 +161,7 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
         "last_edited",
         "country",
         "local_group_types",
+        ("last_edited", DateRangeFilter)
     ]
     search_fields = [
         "name",

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -76,9 +76,10 @@ class LocalGroupResource(ModelResource):
 
     def before_import_row(self, row: dict, **kwargs) -> dict:
         row["local_group_types"] = [type for type in self.hydrate_local_group_types(row["types"]) if type is not None]
-        organisers_users, organisers_non_users = self.hydrate_organisers((row))
+        organisers_users, organisers_non_users = self.hydrate_organisers(row)
         row["organisers"] = ",".join(map(lambda x: str(x.id), organisers_users))
         row["organisers_freetext"] = ",".join(organisers_non_users)
+
         return super().before_import_row(row, **kwargs)
 
     def hydrate_local_group_type(self, group_type_raw: str) -> Optional[LocalGroupType]:
@@ -140,7 +141,7 @@ class LocalGroupResource(ModelResource):
 
 @admin.register(LocalGroup)
 class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
-    actions = ["export_csv"]
+    actions = ["export_csv", "make_not_public"]
     list_display = [
         "name",
         "local_group_type",
@@ -182,6 +183,11 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
         fieldnames.append("organisers_emails")
         return ExportCsvMixin.export_csv(
             self, request, queryset, fieldnames, "localgroups"
+        )
+
+    def make_not_public(self, request, queryset, **kwargs):
+        queryset.update(
+            is_public=False
         )
 
 

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -1,9 +1,9 @@
 import autoslug
 from django import urls
-from django.core.cache import cache
 from django.conf import settings
 from django.contrib.postgres import fields as postgres_fields
 from django.core import validators
+from django.core.cache import cache
 from django.core.validators import MaxLengthValidator
 from django.db import models
 from django.db.models.signals import post_save
@@ -120,6 +120,7 @@ class LocalGroup(models.Model):
             else:
                 values.append(getattr(self, field))
         return values
+
 
 @receiver(post_save, sender=LocalGroup)
 def clear_the_cache(**kwargs):

--- a/eahub/tests/test_localgroups_admin.py
+++ b/eahub/tests/test_localgroups_admin.py
@@ -1,0 +1,75 @@
+from django.test import TestCase
+
+from eahub.base.models import User
+from eahub.localgroups.models import LocalGroup, Organisership
+from eahub.localgroups.admin import LocalGroupResource
+from eahub.profiles.models import Profile
+
+
+class LocalGroupAdminTestCase(TestCase):
+    def setUp(self):
+      local_group = LocalGroup()
+      local_group.id = 1
+      local_group.save()
+      self.local_group = local_group
+
+      user1 = User()
+      user1.email = "1@email.com"
+      user1.save()
+      self.user_peter_1 = user1
+
+      user2 = User()
+      user2.email = "2@email.com"
+      user2.save()
+
+      user3 = User()
+      user3.email = "3@email.com"
+      user3.save()
+
+      profile1 = Profile()
+      name1 = "Peter"
+      profile1.name = name1
+      profile1.user = user1
+      profile1.save()
+
+      profile2 = Profile()
+      name2 = "Mary"
+      profile2.name = name2
+      profile2.user = user2
+      profile2.save()
+
+      profile3 = Profile()
+      name3 = "Peter"
+      profile3.name = name3
+      profile3.user = user3
+      profile3.save()
+
+      self.user_peter_2 = user3
+
+      o1 = Organisership(user=user1, local_group=local_group)
+      o1.save()
+
+      o2 = Organisership(user=user2, local_group=local_group)
+      o2.save()
+
+    def test_hydrate_organiser_where_multiple_users_with_same_name_and_one_user_already_organiser(self):
+      localGroupResource = LocalGroupResource()
+
+      row = { "id": "1" }
+
+      user = localGroupResource.hydrate_organiser("Peter", row)
+
+      self.assertEqual(self.user_peter_1, user)
+
+    def test_hydrate_organiser_where_multiple_users_with_same_name_and_already_organisers(self):
+      o = Organisership(user=self.user_peter_2, local_group=self.local_group)
+      o.save()
+
+      localGroupResource = LocalGroupResource()
+
+      row = { "id": "1" }
+
+      user = localGroupResource.hydrate_organiser("Peter", row)
+
+      self.assertEqual(self.user_peter_2, user)
+

--- a/eahub/tests/test_localgroups_admin.py
+++ b/eahub/tests/test_localgroups_admin.py
@@ -1,75 +1,74 @@
 from django.test import TestCase
 
 from eahub.base.models import User
-from eahub.localgroups.models import LocalGroup, Organisership
 from eahub.localgroups.admin import LocalGroupResource
+from eahub.localgroups.models import LocalGroup, Organisership
 from eahub.profiles.models import Profile
 
 
 class LocalGroupAdminTestCase(TestCase):
     def setUp(self):
-      local_group = LocalGroup()
-      local_group.id = 1
-      local_group.save()
-      self.local_group = local_group
+        local_group = LocalGroup()
+        local_group.id = 1
+        local_group.save()
+        self.local_group = local_group
 
-      user1 = User()
-      user1.email = "1@email.com"
-      user1.save()
-      self.user_peter_1 = user1
+        user1 = User()
+        user1.email = "1@email.com"
+        user1.save()
+        self.user_peter_1 = user1
 
-      user2 = User()
-      user2.email = "2@email.com"
-      user2.save()
+        user2 = User()
+        user2.email = "2@email.com"
+        user2.save()
 
-      user3 = User()
-      user3.email = "3@email.com"
-      user3.save()
+        user3 = User()
+        user3.email = "3@email.com"
+        user3.save()
 
-      profile1 = Profile()
-      name1 = "Peter"
-      profile1.name = name1
-      profile1.user = user1
-      profile1.save()
+        profile1 = Profile()
+        name1 = "Peter"
+        profile1.name = name1
+        profile1.user = user1
+        profile1.save()
 
-      profile2 = Profile()
-      name2 = "Mary"
-      profile2.name = name2
-      profile2.user = user2
-      profile2.save()
+        profile2 = Profile()
+        name2 = "Mary"
+        profile2.name = name2
+        profile2.user = user2
+        profile2.save()
 
-      profile3 = Profile()
-      name3 = "Peter"
-      profile3.name = name3
-      profile3.user = user3
-      profile3.save()
+        profile3 = Profile()
+        name3 = "Peter"
+        profile3.name = name3
+        profile3.user = user3
+        profile3.save()
 
-      self.user_peter_2 = user3
+        self.user_peter_2 = user3
 
-      o1 = Organisership(user=user1, local_group=local_group)
-      o1.save()
+        o1 = Organisership(user=user1, local_group=local_group)
+        o1.save()
 
-      o2 = Organisership(user=user2, local_group=local_group)
-      o2.save()
+        o2 = Organisership(user=user2, local_group=local_group)
+        o2.save()
 
-    def test_hydrate_organiser_where_multiple_users_with_same_name_and_one_user_already_organiser(self):
-      localGroupResource = LocalGroupResource()
+    def test_hydrate_organiser_where_users_with_same_name_and_one_already_organiser(
+        self
+    ):
+        local_group_resource = LocalGroupResource()
+        row = {"id": "1"}
+        user = local_group_resource.hydrate_organiser("Peter", row)
 
-      row = { "id": "1" }
+        self.assertEqual(self.user_peter_1, user)
 
-      user = localGroupResource.hydrate_organiser("Peter", row)
+    def test_hydrate_organiser_where_users_with_same_name_and_already_organisers(
+        self
+    ):
+        o = Organisership(user=self.user_peter_2, local_group=self.local_group)
+        o.save()
 
-      self.assertEqual(self.user_peter_1, user)
+        local_group_resource = LocalGroupResource()
+        row = {"id": "1"}
+        user = local_group_resource.hydrate_organiser("Peter", row)
 
-    def test_hydrate_organiser_where_multiple_users_with_same_name_and_already_organisers(self):
-      o = Organisership(user=self.user_peter_2, local_group=self.local_group)
-      o.save()
-
-      localGroupResource = LocalGroupResource()
-
-      row = { "id": "1" }
-
-      user = localGroupResource.hydrate_organiser("Peter", row)
-
-      self.assertEqual(self.user_peter_2, user)
-
+        self.assertEqual(self.user_peter_2, user)


### PR DESCRIPTION
* Fixes issues with group data import to address #989:  
  * Issue that prevented groups from being updated (rather than newly added) caused by utf-8 BOM  
  * Issue with importing group types (required creating own Widget for Enums)  
  * Maps organiser names to profiles      
* Adds functionality for marking selected groups in admin panel public/not_public
* Adds DateRangeFilter for "last_updated" field

