### PR TITLE
Allow filtering users by giving pledge

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ docker-compose run --rm web pytest
 npm test
 ```
 
+Running a particular python test, e.g., test_localgroups_model.py:  
+```
+docker-compose run --rm web pytest eahub/tests/test_localgroups_model.py
+```
+
+
 ## Formatting Code
 ```
 docker-compose run --rm web black eahub

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -14,11 +14,12 @@ def user_display(user):
 
 
 class ExportCsvMixin:
-    def export_csv(self, request, queryset, field_names, filename):
+    def export_csv(self, request, queryset, model, filename):
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = "attachment; filename={}.csv".format(filename)
         writer = csv.writer(response)
 
+        field_names = model.get_exportable_field_names()
         writer.writerow(field_names)
         for obj in queryset:
             writer.writerow(obj.convert_to_row(field_names))

--- a/eahub/localgroups/admin.py
+++ b/eahub/localgroups/admin.py
@@ -194,15 +194,8 @@ class LocalGroupAdmin(ImportExportMixin, admin.ModelAdmin, ExportCsvMixin):
     resource_class = LocalGroupResource
 
     def export_csv(self, request, queryset, **kwargs):
-        meta = LocalGroup._meta
-        fieldnames = [
-            field.name
-            for field in meta.fields + meta.many_to_many
-            if field.name != "local_group_type"
-        ]
-        fieldnames.append("organisers_emails")
         return ExportCsvMixin.export_csv(
-            self, request, queryset, fieldnames, "localgroups"
+            self, request, queryset, LocalGroup, "localgroups"
         )
 
     def make_public(self, request, queryset, **kwargs):

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -121,6 +121,16 @@ class LocalGroup(models.Model):
                 values.append(getattr(self, field))
         return values
 
+    @staticmethod
+    def get_exportable_field_names():
+        fieldnames = [
+            field.name
+            for field in LocalGroup._meta.fields + LocalGroup._meta.many_to_many
+            if field.name != "local_group_type"
+        ]
+        fieldnames.append("organisers_emails")
+        return fieldnames
+
 
 @receiver(post_save, sender=LocalGroup)
 def clear_the_cache(**kwargs):

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -5,8 +5,8 @@ from . import models
 
 
 class GivingPledgesFilter(admin.SimpleListFilter):
-    title = 'giving_pledges_readable'
-    parameter_name = 'giving_pledge'
+    title = "giving_pledges_readable"
+    parameter_name = "giving_pledge"
 
     def lookups(self, request, model_admin):
         return models.GivingPledge.choices()
@@ -28,14 +28,14 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
         "email_visible",
         "country",
         "available_to_volunteer",
-        "giving_pledges_readable"
+        "giving_pledges_readable",
     )
     list_filter = [
         "is_approved",
         "is_public",
         "email_visible",
         "available_to_volunteer",
-        GivingPledgesFilter
+        GivingPledgesFilter,
     ]
     search_fields = ["user__email", "name"]
     ordering = ["-user__date_joined"]
@@ -49,7 +49,8 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
         return obj.get_pretty_giving_pledges()
 
     giving_pledges_readable.short_description = "Giving Pledges"
-    giving_pledges_readable.admin_order_field = 'profile.giving_pledges'
+    giving_pledges_readable.admin_order_field = "profile.giving_pledges"
+
 
 admin.site.register(models.Profile, ProfileAdmin)
 admin.site.register(models.ProfileSlug)

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -25,11 +25,18 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
         "name",
         "is_public",
         "is_approved",
+        "email_visible",
         "country",
         "available_to_volunteer",
         "giving_pledges_readable"
     )
-    list_filter = [GivingPledgesFilter, "is_approved", "is_public", "available_to_volunteer"]
+    list_filter = [
+        "is_approved",
+        "is_public",
+        "email_visible",
+        "available_to_volunteer",
+        GivingPledgesFilter
+    ]
     search_fields = ["user__email", "name"]
     ordering = ["-user__date_joined"]
 

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -41,10 +41,8 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
     ordering = ["-user__date_joined"]
 
     def export_csv(self, request, queryset):
-        meta = models.Profile._meta
-        fieldnames = [field.name for field in meta.fields + meta.many_to_many]
         return utils.ExportCsvMixin.export_csv(
-            self, request, queryset, fieldnames, "profiles"
+            self, request, queryset, models.Profile, "profiles"
         )
 
     def giving_pledges_readable(self, obj):

--- a/eahub/profiles/admin.py
+++ b/eahub/profiles/admin.py
@@ -4,17 +4,32 @@ from ..base import utils
 from . import models
 
 
-@admin.register(models.Profile)
+class GivingPledgesFilter(admin.SimpleListFilter):
+    title = 'giving_pledges_readable'
+    parameter_name = 'giving_pledge'
+
+    def lookups(self, request, model_admin):
+        return models.GivingPledge.choices()
+
+    def queryset(self, request, queryset):
+        if self.value():
+            return queryset.filter(giving_pledges__contains=[self.value()])
+        else:
+            return queryset
+
+
 class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
     actions = ["export_csv"]
-    list_display = [
+    model = models.Profile
+    list_display = (
         "name",
         "is_public",
         "is_approved",
         "country",
         "available_to_volunteer",
-    ]
-    list_filter = ["is_approved", "is_public", "available_to_volunteer"]
+        "giving_pledges_readable"
+    )
+    list_filter = [GivingPledgesFilter, "is_approved", "is_public", "available_to_volunteer"]
     search_fields = ["user__email", "name"]
     ordering = ["-user__date_joined"]
 
@@ -25,5 +40,11 @@ class ProfileAdmin(admin.ModelAdmin, utils.ExportCsvMixin):
             self, request, queryset, fieldnames, "profiles"
         )
 
+    def giving_pledges_readable(self, obj):
+        return obj.get_pretty_giving_pledges()
 
+    giving_pledges_readable.short_description = "Giving Pledges"
+    giving_pledges_readable.admin_order_field = 'profile.giving_pledges'
+
+admin.site.register(models.Profile, ProfileAdmin)
 admin.site.register(models.ProfileSlug)

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -536,9 +536,11 @@ class Profile(models.Model):
 
     @staticmethod
     def get_exportable_field_names():
-        return [field.name for field in Profile._meta.fields + Profile._meta.many_to_many if "_other" not in field.name]
-
-
+        return [
+            field.name
+            for field in Profile._meta.fields + Profile._meta.many_to_many
+            if "_other" not in field.name
+        ]
 
 
 @receiver(post_save, sender=Profile)

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -534,6 +534,12 @@ class Profile(models.Model):
     ) -> List[str]:
         return [item[1] for item in enum_cls.choices() if item[0] in array]
 
+    @staticmethod
+    def get_exportable_field_names():
+        return [field.name for field in Profile._meta.fields + Profile._meta.many_to_many if "_other" not in field.name]
+
+
+
 
 @receiver(post_save, sender=Profile)
 def clear_the_cache(**kwargs):

--- a/eahub/tests/test_localgroups_admin.py
+++ b/eahub/tests/test_localgroups_admin.py
@@ -61,9 +61,7 @@ class LocalGroupAdminTestCase(TestCase):
 
         self.assertEqual(self.user_peter_1, user)
 
-    def test_hydrate_organiser_where_users_with_same_name_and_already_organisers(
-        self
-    ):
+    def test_hydrate_organiser_where_users_with_same_name_and_already_organisers(self):
         o = Organisership(user=self.user_peter_2, local_group=self.local_group)
         o.save()
 

--- a/eahub/tests/test_localgroups_model.py
+++ b/eahub/tests/test_localgroups_model.py
@@ -51,3 +51,34 @@ class LocalGroupTestCase(TestCase):
         organisers_names = local_group.organisers_names()
 
         self.assertEqual("User profile missing", organisers_names)
+
+    def test_get_exportable_field_names(self):
+        actual = LocalGroup.get_exportable_field_names()
+
+        expected_field_names = [
+            "id",
+            "slug",
+            "is_public",
+            "name",
+            "is_active",
+            "organisers_freetext",
+            "local_group_types",
+            "city_or_town",
+            "region",
+            "country",
+            "lat",
+            "lon",
+            "website",
+            "other_website",
+            "facebook_group",
+            "facebook_page",
+            "email",
+            "meetup_url",
+            "airtable_record",
+            "last_edited",
+            "other_info",
+            "organisers",
+            "organisers_emails",
+        ]
+
+        self.assertListEqual(expected_field_names, actual)

--- a/eahub/tests/test_profile_model.py
+++ b/eahub/tests/test_profile_model.py
@@ -1,0 +1,40 @@
+from django.test import TestCase
+
+from eahub.profiles.models import Profile
+
+
+class ProfileTestCase(TestCase):
+    def test_get_exportable_field_names(self):
+        actual = Profile.get_exportable_field_names()
+
+        expected_field_names = [
+            "id",
+            "user",
+            "slug",
+            "is_public",
+            "is_approved",
+            "name",
+            "image",
+            "city_or_town",
+            "country",
+            "linkedin_url",
+            "facebook_url",
+            "personal_website_url",
+            "lat",
+            "lon",
+            "cause_areas",
+            "available_to_volunteer",
+            "open_to_job_offers",
+            "expertise_areas",
+            "career_interest_areas",
+            "available_as_speaker",
+            "email_visible",
+            "topics_i_speak_about",
+            "organisational_affiliations",
+            "summary",
+            "giving_pledges",
+            "legacy_record",
+            "local_groups",
+        ]
+
+        self.assertListEqual(expected_field_names, actual)


### PR DESCRIPTION
* Adds filter of users by giving pledge to admin panel  
* Adds filter of users by whether there email is visible to admin panel  
* Fixes bug with profiles export such that values where not matched to correct columns  

Triggered by request from GWWC to get a list of all public users who have taken the pledge. Adding filter to email since we don't want to share hidden emails  

closes #1049  