### PR TITLE
Set admins as sender on messaging

### DIFF
--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -134,9 +134,10 @@ class SendGroupMessageView(SendMessageView):
         send_mail(
             f"{sender_name} wants to connect with {recipient.name}!",
             txt_message,
-            sender_email_address,
+            admins_email,
             recipient.get_messaging_emails(self.request),
             html_message=html_message,
+            reply_to=sender_email_address
         )
 
         messages.success(

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth import mixins as auth_mixins
 from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
-from django.core.mail import send_mail
+from django.core.mail import EmailMultiAlternatives, send_mail
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
@@ -106,17 +106,20 @@ class SendGroupMessageView(SendMessageView):
         return LocalGroup.objects.get(slug=self.kwargs["slug"], is_public=True)
 
     def form_valid(self, form):
+        message = form.cleaned_data["your_message"]
         recipient = self.profile()
         sender_name = form.cleaned_data["your_name"]
+        subject = f"{sender_name} wants to connect with {recipient.name}!"
         sender_email_address = form.cleaned_data["your_email_address"]
         feedback_url = FeedbackURLConfig.get_solo().site_url
         admins_email = get_admin_email()
+
         txt_message = render_to_string(
             "emails/message_group.txt",
             {
                 "sender_name": sender_name,
                 "group_name": recipient.name,
-                "message": form.cleaned_data["your_message"],
+                "message": message,
                 "feedback_url": feedback_url,
                 "admins_email": admins_email,
             },
@@ -126,19 +129,21 @@ class SendGroupMessageView(SendMessageView):
             {
                 "sender_name": sender_name,
                 "group_name": recipient.name,
-                "message": form.cleaned_data["your_message"],
+                "message": message,
                 "feedback_url": feedback_url,
                 "admins_email": admins_email,
             },
         )
-        send_mail(
-            f"{sender_name} wants to connect with {recipient.name}!",
-            txt_message,
-            admins_email,
-            recipient.get_messaging_emails(self.request),
-            html_message=html_message,
-            reply_to=sender_email_address
-        )
+
+        email = EmailMultiAlternatives(
+            subject=subject,
+            body=txt_message,
+            from_email=admins_email,
+            to=recipient.get_messaging_emails(self.request),
+            reply_to=[sender_email_address])
+        email.attach_alternative(html_message, "text/html")
+
+        email.send()
 
         messages.success(
             self.request, "Your message to " + recipient.name + " has been sent"

--- a/eahub/profiles/views.py
+++ b/eahub/profiles/views.py
@@ -133,9 +133,10 @@ class SendProfileMessageView(SendMessageView):
         send_mail(
             f"{sender_name} wants to connect with you!",
             txt_message,
-            sender_email_address,
+            admin_email,
             [recipient.user.email],
             html_message=html_message,
+            reply_to = sender_email_address
         )
         messages.success(
             self.request, "Your message to " + recipient.name + " has been sent"

--- a/eahub/templates/emails/message_group.html
+++ b/eahub/templates/emails/message_group.html
@@ -1,6 +1,7 @@
 <p>Dear {{ group_name }} admin,</p>
 <p>{{ sender_name }} has sent {{ group_name }} a message:</p>
-<p>{{ message }}</p>
+<p style="font-style: italic">{{ message }}</p>
+<p>You can respond to them by replying to this email.</p>
 <p>Thanks,</p>
 <p>EA Hub</p>
 <p>

--- a/eahub/templates/emails/message_group.txt
+++ b/eahub/templates/emails/message_group.txt
@@ -1,7 +1,13 @@
 Dear {{ group_name }} admin,
+
 {{ sender_name }} has sent {{ group_name }} a message:
+
 {{ message }}
+
+You can respond to them by replying to this email.
+
 Thanks,
+
 EA Hub
 
 Feedback: {{ feedback_url }}

--- a/eahub/templates/emails/message_group.txt
+++ b/eahub/templates/emails/message_group.txt
@@ -2,7 +2,9 @@ Dear {{ group_name }} admin,
 
 {{ sender_name }} has sent {{ group_name }} a message:
 
+---
 {{ message }}
+---
 
 You can respond to them by replying to this email.
 

--- a/eahub/templates/emails/message_profile.html
+++ b/eahub/templates/emails/message_profile.html
@@ -1,6 +1,7 @@
 <p>Dear {{ recipient }},</p>
 <p>{{ sender_name }} has sent you a message:</p>
-<p>{{ message }}</p>
+<p style="font-style: italic">{{ message }}</p>
+<p>You can respond to them by replying to this email.</p>
 <p>Thanks,</p>
 <p>EA Hub</p>
 <p>

--- a/eahub/templates/emails/message_profile.txt
+++ b/eahub/templates/emails/message_profile.txt
@@ -4,7 +4,10 @@ Dear {{ recipient }},
 
 {{ message }}
 
+You can respond to them by replying to this email.
+
 Thanks,
+
 EA Hub
 
 Feedback: {{ feedback_url }}

--- a/eahub/templates/emails/message_profile.txt
+++ b/eahub/templates/emails/message_profile.txt
@@ -2,7 +2,9 @@ Dear {{ recipient }},
 
 {{ sender_name }} has sent you a message:
 
+---
 {{ message }}
+---
 
 You can respond to them by replying to this email.
 


### PR DESCRIPTION
* Set admins as sender on messaging to avoid sparkpost error because user's email addresses' domain isn't verified with our sparkpost account.  
* Adds clear info that user can repond by replying to email  
* Sets message apart from rest of email