### PR TITLE
Remove message link on profile until messaging switched on

### DIFF
--- a/eahub/base/static/components/search-profiles/search.html
+++ b/eahub/base/static/components/search-profiles/search.html
@@ -79,11 +79,6 @@
                                                     <i class="fab fa-linkedin-in"></i>
                                                 </a>
                                             </div>
-                                            <div class="search__hit-social-link" v-if="item.messaging_url_if_can_receive_message">
-                                                <a v-bind:href="item.messaging_url_if_can_receive_message">
-                                                     <i class="fa fa-envelope"></i>
-                                                </a>
-                                            </div>
                                             <div class="search__hit-social-link" v-if="item.facebook_url">
                                                 <a v-bind:href="item.facebook_url" rel="nofollow" class="search__hit-href">
                                                     <i class="fab fa-facebook-f"></i>

--- a/eahub/templates/emails/message_profile.txt
+++ b/eahub/templates/emails/message_profile.txt
@@ -8,8 +8,6 @@ Dear {{ recipient }},
 
 You can respond to them by replying to this email.
 
-You can respond to them by replying to this email.
-
 Thanks,
 
 EA Hub

--- a/eahub/templates/emails/message_profile.txt
+++ b/eahub/templates/emails/message_profile.txt
@@ -8,6 +8,8 @@ Dear {{ recipient }},
 
 You can respond to them by replying to this email.
 
+You can respond to them by replying to this email.
+
 Thanks,
 
 EA Hub


### PR DESCRIPTION
* Link currently gives users a 404 if clicked on since messaging not switched on. 
* Couldn't find a quick solution to use feature toggle this within vueJS so simply removed it from html for now