### PR TITLE
Add messaging link to profiles page

### DIFF
--- a/eahub/base/static/components/search-profiles/search.html
+++ b/eahub/base/static/components/search-profiles/search.html
@@ -79,6 +79,11 @@
                                                     <i class="fab fa-linkedin-in"></i>
                                                 </a>
                                             </div>
+                                            <div class="search__hit-social-link" v-if="item.messaging_url_if_can_receive_message">
+                                                <a v-bind:href="item.messaging_url_if_can_receive_message">
+                                                     <i class="fa fa-envelope"></i>
+                                                </a>
+                                            </div>
                                             <div class="search__hit-social-link" v-if="item.facebook_url">
                                                 <a v-bind:href="item.facebook_url" rel="nofollow" class="search__hit-href">
                                                     <i class="fab fa-facebook-f"></i>


### PR DESCRIPTION
* Had removed this when we deployed messaging, but feature-toggled off.
* This commit should only be deployed once we want to release messaging (i.e., feature-toggle it on)