### PR TITLE
Set from field on user messaging emails correctly

### DIFF
--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -14,10 +14,6 @@ def user_display(user):
     return profile.get_full_name()
 
 
-def get_admin_email():
-    return settings.DEFAULT_FROM_EMAIL
-
-
 class ExportCsvMixin:
     def export_csv(self, request, queryset, model, filename):
         response = HttpResponse(content_type="text/csv")

--- a/eahub/base/utils.py
+++ b/eahub/base/utils.py
@@ -15,7 +15,7 @@ def user_display(user):
 
 
 def get_admin_email():
-    return list(settings.ADMINS)[0]
+    return settings.DEFAULT_FROM_EMAIL
 
 
 class ExportCsvMixin:

--- a/eahub/config/settings.py
+++ b/eahub/config/settings.py
@@ -351,11 +351,6 @@ else:
         "provided together"
     )
 
-# feature flags
-FLAGS = {
-    "MESSAGING_FLAG": [("boolean", env.bool("IS_MESSAGING_ENABLED", default=False))]
-}
-
 
 ADMIN_REORDER = [
     {

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -9,7 +9,6 @@ from django.db import models
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django_enumfield import enum
-from flags.state import flag_enabled
 from geopy import geocoders
 
 from eahub.base.models import User
@@ -107,13 +106,13 @@ class LocalGroup(models.Model):
         )
 
     def get_messaging_emails(self, request):
-        if not self.email and flag_enabled("MESSAGING_FLAG", request=request):
+        if not self.email:
             return [
                 user.email
                 for user in self.organisers.all()
                 if user.profile.allow_messaging
             ]
-        elif self.email:
+        else:
             return [self.email]
 
     def geocode(self):

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -1,0 +1,55 @@
+from django.core import mail
+from django.template.response import TemplateResponse
+from django.urls import reverse
+
+from eahub.localgroups.models import Organisership
+from eahub.tests.cases import EAHubTestCase
+
+
+class LocalGroupsMessagingTestCase(EAHubTestCase):
+    def test_group_messaging(self):
+        profile_sender = self.gen.profile()
+        localgroup_recipient = self.gen.group()
+        profile_organiser = self.gen.profile()
+        o1 = Organisership(
+            user=profile_organiser.user, local_group=localgroup_recipient
+        )
+        o1.save()
+
+        message_body = "test message body"
+        self.client.force_login(profile_sender.user)
+        response: TemplateResponse = self.client.post(
+            path=reverse("message_group", args=[localgroup_recipient.slug]),
+            data=dict(
+                your_name=profile_sender.get_full_name(),
+                your_email_address=profile_sender.user.email,
+                your_message=message_body,
+            ),
+            follow=True,
+        )
+        self.assertEqual(200, response.status_code)
+        self.assertIn(message_body, mail.outbox[0].body)
+        self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
+        self.assertEqual(profile_organiser.user.email, mail.outbox[0].to[0][0])
+
+    def test_group_messaging_not_to_users_with_messaging_disabled(self):
+        profile_sender = self.gen.profile()
+        localgroup_recipient = self.gen.group()
+        profile_organiser = self.gen.profile(allow_messaging=False)
+        o1 = Organisership(
+            user=profile_organiser.user, local_group=localgroup_recipient
+        )
+        o1.save()
+
+        message_body = "test message body"
+        self.client.force_login(profile_sender.user)
+        response: TemplateResponse = self.client.post(
+            path=reverse("message_group", args=[localgroup_recipient.slug]),
+            data=dict(
+                your_name=profile_sender.get_full_name(),
+                your_email_address=profile_sender.user.email,
+                your_message=message_body,
+            ),
+            follow=True,
+        )
+        self.assertEqual(500, response.status_code)

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -8,7 +8,33 @@ from eahub.tests.cases import EAHubTestCase
 
 
 class LocalGroupsMessagingTestCase(EAHubTestCase):
-    def test_group_messaging(self):
+    def test_group_messaging_sends_to_group_email(self):
+        profile_sender = self.gen.profile()
+        localgroup_recipient = self.gen.group(email="group@test.com")
+
+        message_body = "test message body"
+        self.client.force_login(profile_sender.user)
+        response: TemplateResponse = self.client.post(
+            path=reverse("message_group", args=[localgroup_recipient.slug]),
+            data=dict(
+                your_name=profile_sender.get_full_name(),
+                your_email_address=profile_sender.user.email,
+                your_message=message_body,
+            ),
+            follow=True,
+        )
+
+        self.assertEqual(200, response.status_code)
+        self.assertIn(message_body, mail.outbox[0].body)
+        self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
+        self.assertEqual(localgroup_recipient.email, mail.outbox[0].to[0])
+
+        self.assertEqual("GROUP", MessagingLog.objects.filter(
+            sender_email=profile_sender.user.email,
+            recipient_email=localgroup_recipient.email
+            )[0].recipient_type)
+
+    def test_group_messaging_sends_to_first_organiser(self):
         profile_sender = self.gen.profile()
         localgroup_recipient = self.gen.group()
         profile_organiser = self.gen.profile()
@@ -35,21 +61,17 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
             follow=True,
         )
 
-        logs = MessagingLog.objects.filter(
-            sender_email=profile_sender.user.email
-        )
+        first_organiser = sorted([profile_organiser.user.email, profile_organiser_2.user.email])[0]
 
         self.assertEqual(200, response.status_code)
         self.assertIn(message_body, mail.outbox[0].body)
         self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
-        self.assertIn(profile_organiser.user.email, mail.outbox[0].to[0])
-        self.assertIn(profile_organiser_2.user.email, mail.outbox[0].to[0])
+        self.assertEqual(first_organiser, mail.outbox[0].to[0])
 
-        self.assertEqual(1, len(logs))
-        self.assertEqual("GROUP", logs[0].recipient_type)
-        self.assertIn(profile_organiser.user.email, logs[0].recipient_email)
-        self.assertIn(profile_organiser_2.user.email, logs[0].recipient_email)
-        self.assertIn(profile_organiser.user.email, logs[0].recipient_email)
+        self.assertEqual("GROUP", MessagingLog.objects.filter(
+            sender_email=profile_sender.user.email,
+            recipient_email=first_organiser
+            )[0].recipient_type)
 
     def test_group_messaging_throws_if_no_available_emails(self):
         profile_sender = self.gen.profile()

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -29,10 +29,13 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
         self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
         self.assertEqual(localgroup_recipient.email, mail.outbox[0].to[0])
 
-        self.assertEqual("GROUP", MessagingLog.objects.filter(
-            sender_email=profile_sender.user.email,
-            recipient_email=localgroup_recipient.email
-            )[0].recipient_type)
+        self.assertEqual(
+            "GROUP",
+            MessagingLog.objects.filter(
+                sender_email=profile_sender.user.email,
+                recipient_email=localgroup_recipient.email,
+            )[0].recipient_type,
+        )
 
     def test_group_messaging_sends_to_first_organiser(self):
         profile_sender = self.gen.profile()
@@ -61,17 +64,21 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
             follow=True,
         )
 
-        first_organiser = sorted([profile_organiser.user.email, profile_organiser_2.user.email])[0]
+        first_organiser = sorted(
+            [profile_organiser.user.email, profile_organiser_2.user.email]
+        )[0]
 
         self.assertEqual(200, response.status_code)
         self.assertIn(message_body, mail.outbox[0].body)
         self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
         self.assertEqual(first_organiser, mail.outbox[0].to[0])
 
-        self.assertEqual("GROUP", MessagingLog.objects.filter(
-            sender_email=profile_sender.user.email,
-            recipient_email=first_organiser
-            )[0].recipient_type)
+        self.assertEqual(
+            "GROUP",
+            MessagingLog.objects.filter(
+                sender_email=profile_sender.user.email, recipient_email=first_organiser
+            )[0].recipient_type,
+        )
 
     def test_group_messaging_throws_if_no_available_emails(self):
         profile_sender = self.gen.profile()

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -2,6 +2,7 @@ from django.core import mail
 from django.template.response import TemplateResponse
 from django.urls import reverse
 
+from eahub.base.models import MessagingLog
 from eahub.localgroups.models import Organisership
 from eahub.tests.cases import EAHubTestCase
 
@@ -11,10 +12,16 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
         profile_sender = self.gen.profile()
         localgroup_recipient = self.gen.group()
         profile_organiser = self.gen.profile()
+        profile_organiser_2 = self.gen.profile()
         o1 = Organisership(
             user=profile_organiser.user, local_group=localgroup_recipient
         )
         o1.save()
+
+        o2 = Organisership(
+            user=profile_organiser_2.user, local_group=localgroup_recipient
+        )
+        o2.save()
 
         message_body = "test message body"
         self.client.force_login(profile_sender.user)
@@ -27,12 +34,24 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
             ),
             follow=True,
         )
+
+        logs = MessagingLog.objects.filter(
+            sender_email=profile_sender.user.email
+        )
+
         self.assertEqual(200, response.status_code)
         self.assertIn(message_body, mail.outbox[0].body)
         self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
-        self.assertEqual(profile_organiser.user.email, mail.outbox[0].to[0][0])
+        self.assertIn(profile_organiser.user.email, mail.outbox[0].to[0])
+        self.assertIn(profile_organiser_2.user.email, mail.outbox[0].to[0])
 
-    def test_group_messaging_not_to_users_with_messaging_disabled(self):
+        self.assertEqual(1, len(logs))
+        self.assertEqual("GROUP", logs[0].recipient_type)
+        self.assertIn(profile_organiser.user.email, logs[0].recipient_email)
+        self.assertIn(profile_organiser_2.user.email, logs[0].recipient_email)
+        self.assertIn(profile_organiser.user.email, logs[0].recipient_email)
+
+    def test_group_messaging_throws_if_no_available_emails(self):
         profile_sender = self.gen.profile()
         localgroup_recipient = self.gen.group()
         profile_organiser = self.gen.profile(allow_messaging=False)

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -8,14 +8,14 @@ from django.contrib.auth.decorators import login_required
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMultiAlternatives, send_mail
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404, redirect
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.views.decorators.http import require_POST
 from django.views.generic import detail as detail_views
 from django.views.generic import edit as edit_views
-from flags.state import flag_enabled
+from djangocms_helpers.utils.send_email import send_email
 from rules.contrib import views as rules_views
 
 from ..base.models import FeedbackURLConfig, MessagingLog
@@ -104,74 +104,54 @@ class ReportGroupAbuseView(ReportAbuseView):
 
 
 class SendGroupMessageView(SendMessageView):
+    def get_initial(self) -> dict:
+        data_initial = super().get_initial()
+        profile = Profile.objects.get(user=self.request.user)
+        data_initial["your_name"] = profile.get_full_name()
+        data_initial["your_email_address"] = profile.user.email
+        return data_initial
+
     def get_recipient(self):
         return LocalGroup.objects.get(slug=self.kwargs["slug"], is_public=True)
 
     def form_valid(self, form):
-        message = form.cleaned_data["your_message"]
         recipient = self.get_recipient()
+        if len(recipient.get_messaging_emails(self.request)) == 0:
+            return HttpResponse(status=500)
         sender_name = form.cleaned_data["your_name"]
-        subject = f"{sender_name} sent a message to {recipient.get_full_name()}"
-        sender_email_address = form.cleaned_data["your_email_address"]
-        feedback_url = FeedbackURLConfig.get_solo().site_url
-        admins_email = settings.DEFAULT_FROM_EMAIL
 
-        txt_message = render_to_string(
-            "emails/message_group.txt",
-            {
+        send_email(
+            email_subject=f"{sender_name} sent you a message",
+            template_path_without_extension="emails/message_profile",
+            template_context={
                 "sender_name": sender_name,
-                "group_name": recipient.name,
-                "message": message,
-                "feedback_url": feedback_url,
-                "admins_email": admins_email,
+                "recipient": recipient.name,
+                "message": form.cleaned_data["your_message"],
+                "admin_email": settings.DEFAULT_FROM_EMAIL,
+                "feedback_url": FeedbackURLConfig.get_solo().site_url,
+                "profile_edit_url": self.request.build_absolute_uri(
+                    reverse("profiles_app:edit_profile")
+                ),
             },
+            email_destination=recipient.get_messaging_emails(self.request),
+            email_from=settings.DEFAULT_FROM_EMAIL,
+            email_reply_to=form.cleaned_data["your_email_address"],
         )
-        html_message = render_to_string(
-            "emails/message_group.html",
-            {
-                "sender_name": sender_name,
-                "group_name": recipient.name,
-                "message": message,
-                "feedback_url": feedback_url,
-                "admins_email": admins_email,
-            },
+        MessagingLog.objects.create(
+            sender_email=form.cleaned_data["your_email_address"],
+            recipient_email=recipient.email,
+            recipient_type=MessagingLog.USER,
         )
-
-        recipient_emails = recipient.get_messaging_emails(self.request)
-
-        email = EmailMultiAlternatives(
-            subject=subject,
-            body=txt_message,
-            from_email=admins_email,
-            to=recipient_emails,
-            reply_to=[sender_email_address],
-        )
-        email.attach_alternative(html_message, "text/html")
-
-        email.send()
-
-        send_action_uuid = uuid.uuid4()
-        for recipient_email in recipient_emails:
-            log = MessagingLog(
-                sender_email=sender_email_address,
-                recipient_email=recipient_email,
-                recipient_type=MessagingLog.GROUP,
-                send_action_uuid=send_action_uuid,
-            )
-            log.save()
 
         messages.success(
-            self.request, f"Your message to {recipient.get_full_name()} has been sent"
+            self.request, f"Your message to {recipient.name} has been sent"
         )
         return redirect(reverse("group", args=([recipient.slug])))
 
     def get(self, request, *args, **kwargs):
         group = self.get_recipient()
 
-        if group.email or (
-            flag_enabled("MESSAGING_FLAG", request=request)
-            and group.has_organisers_with_messaging_enabled()
-        ):
+        if group.email or group.has_organisers_with_messaging_enabled():
             if not request.user.has_perm("profiles.message_users"):
                 raise PermissionDenied
 
@@ -183,11 +163,7 @@ class SendGroupMessageView(SendMessageView):
         group = self.get_recipient()
         if (
             request.user.has_perm("profiles.message_users")
-            and group.email
-            or (
-                flag_enabled("MESSAGING_FLAG", request=request)
-                and group.has_organisers_with_messaging_enabled
-            )
+            and (group.email or group.has_organisers_with_messaging_enabled)
         ):
             return super().post(request, *args, **kwargs)
 

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -19,8 +19,8 @@ from flags.state import flag_enabled
 from rules.contrib import views as rules_views
 
 from ..base.models import FeedbackURLConfig, MessagingLog
-from ..base.utils import get_admin_email
 from ..base.views import ReportAbuseView, SendMessageView
+from ..config import settings
 from ..profiles.models import Profile
 from .forms import LocalGroupForm
 from .models import LocalGroup
@@ -114,7 +114,7 @@ class SendGroupMessageView(SendMessageView):
         subject = f"{sender_name} sent a message to {recipient.get_full_name()}"
         sender_email_address = form.cleaned_data["your_email_address"]
         feedback_url = FeedbackURLConfig.get_solo().site_url
-        admins_email = get_admin_email()
+        admins_email = settings.DEFAULT_FROM_EMAIL
 
         txt_message = render_to_string(
             "emails/message_group.txt",

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -161,9 +161,8 @@ class SendGroupMessageView(SendMessageView):
 
     def post(self, request, *args, **kwargs):
         group = self.get_recipient()
-        if (
-            request.user.has_perm("profiles.message_users")
-            and (group.email or group.has_organisers_with_messaging_enabled)
+        if request.user.has_perm("profiles.message_users") and (
+            group.email or group.has_organisers_with_messaging_enabled
         ):
             return super().post(request, *args, **kwargs)
 

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -139,8 +139,8 @@ class SendGroupMessageView(SendMessageView):
         )
         MessagingLog.objects.create(
             sender_email=form.cleaned_data["your_email_address"],
-            recipient_email=recipient.email,
-            recipient_type=MessagingLog.USER,
+            recipient_email=", ".join(recipient.get_messaging_emails(self.request)),
+            recipient_type=MessagingLog.GROUP,
         )
 
         messages.success(

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -133,13 +133,13 @@ class SendGroupMessageView(SendMessageView):
                     reverse("profiles_app:edit_profile")
                 ),
             },
-            email_destination=recipient.get_messaging_emails(self.request),
+            email_destination=sorted(recipient.get_messaging_emails(self.request))[0],
             email_from=settings.DEFAULT_FROM_EMAIL,
             email_reply_to=form.cleaned_data["your_email_address"],
         )
         MessagingLog.objects.create(
             sender_email=form.cleaned_data["your_email_address"],
-            recipient_email=", ".join(recipient.get_messaging_emails(self.request)),
+            recipient_email=recipient.get_messaging_emails(self.request)[0],
             recipient_type=MessagingLog.GROUP,
         )
 

--- a/eahub/profiles/tests/test_profile_messaging.py
+++ b/eahub/profiles/tests/test_profile_messaging.py
@@ -7,7 +7,7 @@ from eahub.tests.cases import EAHubTestCase
 
 
 class ProfileMessagingTestCase(EAHubTestCase):
-    def test_save_analytics_on_profile_creation(self):
+    def test_profile_messaging(self):
         profile_sender = self.gen.profile()
         profile_recipient = self.gen.profile(visibility=VisibilityEnum.INTERNAL)
         message_body = "test message body"

--- a/eahub/profiles/tests/test_profile_messaging.py
+++ b/eahub/profiles/tests/test_profile_messaging.py
@@ -23,3 +23,5 @@ class ProfileMessagingTestCase(EAHubTestCase):
         )
         self.assertEqual(200, response.status_code)
         self.assertIn(message_body, mail.outbox[0].body)
+        self.assertEqual("EA Hub <admin@eahub.org>", mail.outbox[0].from_email)
+        self.assertEqual(profile_recipient.user.email, mail.outbox[0].to[0])

--- a/eahub/profiles/views.py
+++ b/eahub/profiles/views.py
@@ -10,8 +10,8 @@ from django.views.generic import UpdateView
 from djangocms_helpers.utils.send_email import send_email
 
 from eahub.base.models import FeedbackURLConfig, MessagingLog, User
-from eahub.base.utils import get_admin_email
 from eahub.base.views import ReportAbuseView, SendMessageView
+from eahub.config import settings
 from eahub.feedback.forms import FeedbackForm
 from eahub.profiles.forms import DeleteProfileForm, ProfileForm
 from eahub.profiles.models import Profile, ProfileSlug, VisibilityEnum
@@ -106,14 +106,14 @@ class SendProfileMessageView(SendMessageView):
                 "sender_name": sender_name,
                 "recipient": recipient.get_full_name(),
                 "message": form.cleaned_data["your_message"],
-                "admin_email": get_admin_email(),
+                "admin_email": settings.DEFAULT_FROM_EMAIL,
                 "feedback_url": FeedbackURLConfig.get_solo().site_url,
                 "profile_edit_url": self.request.build_absolute_uri(
                     reverse("profiles_app:edit_profile")
                 ),
             },
             email_destination=recipient.user.email,
-            email_from=get_admin_email(),
+            email_from=settings.DEFAULT_FROM_EMAIL,
             email_reply_to=form.cleaned_data["your_email_address"],
         )
         MessagingLog.objects.create(

--- a/eahub/profiles/views.py
+++ b/eahub/profiles/views.py
@@ -1,11 +1,9 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
-from django.core.mail import EmailMultiAlternatives, send_mail
 from django.forms import ModelForm
 from django.http import Http404, HttpRequest, HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.views.generic import UpdateView
@@ -101,42 +99,23 @@ class SendProfileMessageView(SendMessageView):
     def form_valid(self, form) -> HttpResponse:
         recipient = self.get_recipient()
         sender_name = form.cleaned_data["your_name"]
-        sender_email_address = form.cleaned_data["your_email_address"]
-        message = form.cleaned_data["your_message"]
-        feedback_url = FeedbackURLConfig.get_solo().site_url
-        profile_edit_url = self.request.build_absolute_uri(reverse("profiles_app:edit_profile"))
-        txt_message = render_to_string(
-            "emails/message_profile.txt",
-            {
+        send_email(
+            email_subject=f"{sender_name} sent you a message",
+            template_path_without_extension="emails/message_profile",
+            template_context={
                 "sender_name": sender_name,
                 "recipient": recipient.get_full_name(),
-                "message": message,
+                "message": form.cleaned_data["your_message"],
                 "admin_email": get_admin_email(),
-                "feedback_url": feedback_url,
-                "profile_edit_url": profile_edit_url,
+                "feedback_url": FeedbackURLConfig.get_solo().site_url,
+                "profile_edit_url": self.request.build_absolute_uri(
+                    reverse("profiles_app:edit_profile")
+                ),
             },
+            email_destination=recipient.user.email,
+            email_from=get_admin_email(),
+            email_reply_to=form.cleaned_data["your_email_address"],
         )
-        html_message = render_to_string(
-            "emails/message_profile.html",
-            {
-                "sender_name": sender_name,
-                "recipient": recipient.get_full_name(),
-                "message": message,
-                "admin_email": get_admin_email(),
-                "feedback_url": feedback_url,
-                "profile_edit_url": profile_edit_url,
-            },
-        )
-        email = EmailMultiAlternatives(
-            subject=f"{sender_name} sent you a message",
-            body=txt_message,
-            from_email=get_admin_email(),
-            to=[form.cleaned_data["your_email_address"]],
-            reply_to=[sender_email_address])
-        email.attach_alternative(html_message, "text/html")
-
-        email.send()
-
         MessagingLog.objects.create(
             sender_email=form.cleaned_data["your_email_address"],
             recipient_email=recipient.user.email,

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -25,10 +25,8 @@
     </div>
     <div class="col-xs-12 col-md-6">
       <h1 class="word-break">{{ group.name }}</h1>
-      {% load feature_flags %}
-      {% flag_enabled 'MESSAGING_FLAG' as messaging_flag %}
       {% if request.user.id is not None %}
-      {% if messaging_flag and group.has_organisers_with_messaging_enabled or group.email %}
+      {% if group.has_organisers_with_messaging_enabled or group.email %}
       <div class="btn btn-default purple">
         <a href="{% url 'message_group' group.slug  %}"><i class="fa fa-envelope"></i> Send Message</a>
       </div>


### PR DESCRIPTION
- Some providers were bouncing emails from user to other emails because the "from" field was incorrectly set  
- This MR fixes this and expands messaging unit test to test this  
- Where a group has multiple organisers, sends to first alphabetical one
- Refactors group messaging view to have same pattern as profiles' and adds unit tests  
- Removes toggling of group messaging via messaging flag