### PR TITLE
1248 documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [atom@github.com](mailto:atom@github.com). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [https://contributor-covenant.org/version/1/4][version]
+
+[homepage]: https://contributor-covenant.org
+[version]: https://contributor-covenant.org/version/1/4/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ give as much information as possible:
 * Describe the behaviour you observed after following these steps.    
 * Explain which behaviour expected to see and why.  
 * Provide a screenshot of the bug.  
-* Give information about your environment (browser, device, screen width, etc.)  
+* Give information about your environment (browser, device, screen width, operational system, etc.)  
 
 ### Suggesting Enhancements  
 You can suggest new features and other improvements on [meta.eahub.org](https://meta.eahub.org/c/feature-requests/). You 
@@ -33,7 +33,7 @@ The EA Hub is an open source project and we welcome developers to make contribut
 GitHub issues to work on [here](https://github.com/rtcharity/eahub.org/labels/Good%20First%20Issue).  
 
 If you'd like to work on one of these GitHub issues or would like to pick up another of 
-[our GitHUb issues](https://github.com/rtcharity/eahub.org/issues), **please first get in touch with us** so that we 
+[our GitHub issues](https://github.com/rtcharity/eahub.org/issues), **please first get in touch with us** so that we 
 can discuss which issue would be ideal for you to work on and help you in case you have any questions. To get in touch, 
 join the [contributions channel](https://discord.gg/CQueVjk3fc) on EA Hub's discord server and post a short message 
 that you'd like to contribute.  
@@ -44,8 +44,6 @@ Having clear commit messages on your branch will, however, make the code review 
 guidelines (adapted from [here](https://chris.beams.io/posts/git-commit/)) for all commits, but especially for the final, 
 squashed one:  
 1. Separate subject from body with a blank line
-1. Limit the subject line to 50 characters
-1. Capitalize the subject line
 1. Do not end the subject line with a period
 1. Use the imperative mood in the subject line
 1. Use the body to explain what and why vs. how  
@@ -64,6 +62,10 @@ refactoring, styling changes etc.
 - Explains why these changes were made  
 - Has screenshots of the relevant frontend changes (where applicable)    
 1. All status checks have passed  
+
+The Hub is fully run by volunteers, and it might take us some time to review your pull request. To help us review your 
+pull request in a timely manner, please make sure to reach out to us first on the [contributions channel](https://discord.gg/CQueVjk3fc) 
+and also mention to us there once your pull request is ready to review.  
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@
 Please find our [Code of Conduct](CODE_OF_CONDUCT.md) here. By participating in the EA Hub project you are expected to 
 uphold this code. Please report anny violations to [tech@eahub.org](mailto:tech@eahub.org).  
 
-## How can I contribute?  
+## How Can I Contribute?  
 
-### Reporting bugs  
+### Reporting Bugs  
 Reporting bugs helps us continuously improving the EA Hub.  
 
 If you think you've found a bug, please check first [here](https://github.com/rtcharity/eahub.org/labels/Bug) whether it 
@@ -24,18 +24,50 @@ give as much information as possible:
 * Provide a screenshot of the bug.  
 * Give information about your environment (browser, device, screen width, etc.)  
 
-### Suggesting enhancements  
+### Suggesting Enhancements  
 You can suggest new features and other improvements on [meta.eahub.org](https://meta.eahub.org/c/feature-requests/). You 
 will have to sign up first.  
 
-### Your first code contribution  
+### Your First Code Contribution  
 The EA Hub is an open source project and we welcome developers to make contributions. You can find a list of first good 
 GitHub issues to work on [here](https://github.com/rtcharity/eahub.org/labels/Good%20First%20Issue).  
 
 If you'd like to work on one of these GitHub issues or would like to pick up another of 
 [our GitHUb issues](https://github.com/rtcharity/eahub.org/issues), **please first get in touch with us** so that we 
 can discuss which issue would be ideal for you to work on and help you in case you have any questions. To get in touch, 
-**XXX**.  
+join the [contributions channel](https://discord.gg/CQueVjk3fc) on EA Hub's discord server and post a short message 
+that you'd like to contribute.  
+
+### Git Commit Messages  
+Since we have enabled squash-merging, all commits on your branch will be squashed into one when merging into master. 
+Having clear commit messages on your branch will, however, make the code review easier. Hence, please follow the following 
+guidelines (adapted from [here](https://chris.beams.io/posts/git-commit/)) for all commits, but especially for the final, 
+squashed one:  
+1. Separate subject from body with a blank line
+1. Limit the subject line to 50 characters
+1. Capitalize the subject line
+1. Do not end the subject line with a period
+1. Use the imperative mood in the subject line
+1. Use the body to explain what and why vs. how  
+
+### Pull Requests  
+When making a pull request, put yourself in the shoes of the reviewer and think what information they need to review 
+your code effectively.  
+
+In particular, please make sure that:    
+
+1. The pull request has a clear and meaningful title
+1. You've referenced the GitHub issue the pull request is addressing  
+1. The pull request description:  
+- Mentions which changes were made. Where applicable, make clear which changes are "core" changes, and which are just 
+refactoring, styling changes etc.      
+- Explains why these changes were made  
+- Has screenshots of the relevant frontend changes (where applicable)    
+1. All status checks have passed  
+
+
+
+  
 
  
  

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,16 +38,6 @@ can discuss which issue would be ideal for you to work on and help you in case y
 join the [contributions channel](https://discord.gg/CQueVjk3fc) on EA Hub's discord server and post a short message 
 that you'd like to contribute.  
 
-### Git Commit Messages  
-Since we have enabled squash-merging, all commits on your branch will be squashed into one when merging into master. 
-Having clear commit messages on your branch will, however, make the code review easier. Hence, please follow the following 
-guidelines (adapted from [here](https://chris.beams.io/posts/git-commit/)) for all commits, but especially for the final, 
-squashed one:  
-1. Separate subject from body with a blank line
-1. Do not end the subject line with a period
-1. Use the imperative mood in the subject line
-1. Use the body to explain what and why vs. how  
-
 ### Pull Requests  
 When making a pull request, put yourself in the shoes of the reviewer and think what information they need to review 
 your code effectively.  
@@ -66,6 +56,18 @@ refactoring, styling changes etc.
 The Hub is fully run by volunteers, and it might take us some time to review your pull request. To help us review your 
 pull request in a timely manner, please make sure to reach out to us first on the [contributions channel](https://discord.gg/CQueVjk3fc) 
 and also mention to us there once your pull request is ready to review.  
+
+### Git Commit Messages  
+Since we have enabled squash-merging, all commits on your branch will be squashed into one when merging into master. 
+Having clear commit messages on your branch will, however, make the code review easier. Hence, please follow the following 
+guidelines (adapted from [here](https://chris.beams.io/posts/git-commit/)) for all commits, but especially for the final, 
+squashed one:  
+1. Separate subject from body with a blank line
+1. Do not end the subject line with a period
+1. Use the imperative mood in the subject line
+1. Use the body to explain what and why vs. how  
+
+
 
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to EA Hub  
+
+
+:+1::tada: First off, thanks for taking the time to contribute! :tada::+1:  
+
+## Code of Conduct  
+Please find our [Code of Conduct](CODE_OF_CONDUCT.md) here. By participating in the EA Hub project you are expected to 
+uphold this code. Please report anny violations to [tech@eahub.org](mailto:tech@eahub.org).  
+
+## How can I contribute?  
+
+### Reporting bugs  
+Reporting bugs helps us continuously improving the EA Hub.  
+
+If you think you've found a bug, please check first [here](https://github.com/rtcharity/eahub.org/labels/Bug) whether it 
+has already been reported.  
+
+If the bug has not been reported, please [raise a GitHub issue](https://github.com/rtcharity/eahub.org/issues/new). Please 
+give as much information as possible:  
+* Use a clear and descriptive title for the issue to identify the problem.  
+* Describe the exact steps which reproduce the problem in as many details as possible.  
+* Describe the behaviour you observed after following these steps.    
+* Explain which behaviour expected to see and why.  
+* Provide a screenshot of the bug.  
+* Give information about your environment (browser, device, screen width, etc.)  
+
+### Suggesting enhancements  
+You can suggest new features and other improvements on [meta.eahub.org](https://meta.eahub.org/c/feature-requests/). You 
+will have to sign up first.  
+
+### Your first code contribution  
+The EA Hub is an open source project and we welcome developers to make contributions. You can find a list of first good 
+GitHub issues to work on [here](https://github.com/rtcharity/eahub.org/labels/Good%20First%20Issue).  
+
+If you'd like to work on one of these GitHub issues or would like to pick up another of 
+[our GitHUb issues](https://github.com/rtcharity/eahub.org/issues), **please first get in touch with us** so that we 
+can discuss which issue would be ideal for you to work on and help you in case you have any questions. To get in touch, 
+**XXX**.  
+
+ 
+ 

--- a/README.md
+++ b/README.md
@@ -60,21 +60,3 @@ docker-compose run --rm web bash -c "python manage.py migrate"
 # Browser Support Policy
 
 We support the most recent version of Google Chrome, Mozilla Firefox, Safari, and Microsoft Edge.
-
-# Commit Message Practices
-
-These are primarily for the benefit of maintainers, but all contributors are
-urged to follow them in order to make maintainers' lives easier.
-
-- In general, follow the practices outlined in
-  ["How to Write a Git Commit Message"](https://chris.beams.io/posts/git-commit/)
-  by Chris Beams.
-- As an exception to the above, do not manually wrap the body of a commit
-  message. The main reason for this is because our workflow depends on the
-  GitHub web interface, which doesn't provide an easy way to do this. It does
-  not depend on emailing patches, so the benefits of wrapped lines don't apply.
-  There is arguably some benefit to the usability of `git log`, but it doesn't
-  outweigh the costs.
-- Maintainers should use GitHub's
-  [squash merging](https://help.github.com/en/articles/about-pull-request-merges#squash-and-merge-your-pull-request-commits)
-  exclusively. Merge commits and rebase merging have been disabled in GitHub.


### PR DESCRIPTION
- Add contributing.md (modelled after [atom's](https://github.com/atom/atom/blob/master/CONTRIBUTING.md) ) 
- Add code_of_conduct.md (modelled after the {Contributor Covenant](https://www.contributor-covenant.org/version/1/4/code-of-conduct/)  
- Moves commit practices from readme to contributing.md