### PR TITLE
1264 group bugs fixes

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -52,7 +52,7 @@ This will run all tests, including end-to-end.
 
 Running a particular python test, e.g., test_localgroups_model.py:  
 ```
-docker-compose run --rm web pytest eahub/tests/test_localgroups_model.py
+docker-compose run --rm web pytest eahub/localgroups/tests/test_localgroups_model.py
 ```  
 
 ## Formatting  

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -81,6 +81,13 @@ class LocalGroup(models.Model):
             profile__visibility=VisibilityEnum.PUBLIC
         ).order_by("profile__name", "profile__slug")
 
+    def public_and_internal_organisers(self):
+        from eahub.profiles.models import VisibilityEnum
+
+        return self.organisers.filter(
+            profile__visibility__in=[VisibilityEnum.PUBLIC, VisibilityEnum.INTERNAL]
+        ).order_by("profile__name", "profile__slug")
+
     def organisers_names(self):
         profile_names = []
         for user in self.organisers.all():

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -74,14 +74,14 @@ class LocalGroup(models.Model):
     def get_absolute_url(self):
         return urls.reverse("group", args=[self.slug])
 
-    def public_organisers(self):
+    def public_organisers(self) -> List[User]:
         from eahub.profiles.models import VisibilityEnum
 
         return self.organisers.filter(
             profile__visibility=VisibilityEnum.PUBLIC
         ).order_by("profile__name", "profile__slug")
 
-    def public_and_internal_organisers(self):
+    def public_and_internal_organisers(self) -> List[User]:
         from eahub.profiles.models import VisibilityEnum
 
         return self.organisers.filter(

--- a/eahub/localgroups/models.py
+++ b/eahub/localgroups/models.py
@@ -10,6 +10,8 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django_enumfield import enum
 from geopy import geocoders
+from typing import List, Optional
+
 
 from eahub.base.models import User
 

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -42,7 +42,9 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
 
         profile_organiser = self.gen.profile()
         profile_organiser_2 = self.gen.profile()
-        localgroup_recipient = self.gen.group(organisers=[profile_organiser.user, profile_organiser_2.user])
+        localgroup_recipient = self.gen.group(
+            organisers=[profile_organiser.user, profile_organiser_2.user]
+        )
 
         message_body = "test message body"
         self.client.force_login(profile_sender.user)

--- a/eahub/localgroups/tests/test_localgroups_messaging.py
+++ b/eahub/localgroups/tests/test_localgroups_messaging.py
@@ -39,18 +39,10 @@ class LocalGroupsMessagingTestCase(EAHubTestCase):
 
     def test_group_messaging_sends_to_first_organiser(self):
         profile_sender = self.gen.profile()
-        localgroup_recipient = self.gen.group()
+
         profile_organiser = self.gen.profile()
         profile_organiser_2 = self.gen.profile()
-        o1 = Organisership(
-            user=profile_organiser.user, local_group=localgroup_recipient
-        )
-        o1.save()
-
-        o2 = Organisership(
-            user=profile_organiser_2.user, local_group=localgroup_recipient
-        )
-        o2.save()
+        localgroup_recipient = self.gen.group(organisers=[profile_organiser.user, profile_organiser_2.user])
 
         message_body = "test message body"
         self.client.force_login(profile_sender.user)

--- a/eahub/localgroups/tests/test_localgroups_models.py
+++ b/eahub/localgroups/tests/test_localgroups_models.py
@@ -13,7 +13,7 @@ class LocalGroupTestCase(EAHubTestCase):
 
         profile1 = self.gen.profile(first_name=first_name1, last_name=last_name1)
         profile2 = self.gen.profile(first_name=first_name2, last_name=last_name2)
-        local_group = self.gen.group(users=[profile1.user, profile2.user])
+        local_group = self.gen.group(organisers=[profile1.user, profile2.user])
 
         organiser_names = local_group.organisers_names()
 

--- a/eahub/localgroups/tests/test_localgroups_models.py
+++ b/eahub/localgroups/tests/test_localgroups_models.py
@@ -65,12 +65,16 @@ class LocalGroupTestCase(EAHubTestCase):
         profile_internal = self.gen.profile(visibility=VisibilityEnum.INTERNAL)
         profile_private = self.gen.profile(visibility=VisibilityEnum.PRIVATE)
 
-        group = self.gen.group(organisers=[profile_private.user, profile_internal.user, profile_public.user])
+        group = self.gen.group(
+            organisers=[
+                profile_private.user,
+                profile_internal.user,
+                profile_public.user,
+            ]
+        )
 
         actual = group.public_and_internal_organisers()
 
-        self.assertCountEqual([profile_internal, profile_public], [x.profile for x in list(actual)])
-
-
-
-
+        self.assertCountEqual(
+            [profile_internal, profile_public], [x.profile for x in list(actual)]
+        )

--- a/eahub/localgroups/tests/test_localgroups_models.py
+++ b/eahub/localgroups/tests/test_localgroups_models.py
@@ -22,7 +22,7 @@ class LocalGroupTestCase(EAHubTestCase):
 
     def test_organisers_names_handles_users_without_profiles(self):
         user_without_profile = self.gen.user()
-        local_group = self.gen.group(users=[user_without_profile])
+        local_group = self.gen.group(organisers=[user_without_profile])
 
         organisers_names = local_group.organisers_names()
 
@@ -65,7 +65,7 @@ class LocalGroupTestCase(EAHubTestCase):
         profile_internal = self.gen.profile(visibility=VisibilityEnum.INTERNAL)
         profile_private = self.gen.profile(visibility=VisibilityEnum.PRIVATE)
 
-        group = self.gen.group(users=[profile_private.user, profile_internal.user, profile_public.user])
+        group = self.gen.group(organisers=[profile_private.user, profile_internal.user, profile_public.user])
 
         actual = group.public_and_internal_organisers()
 

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -401,11 +401,15 @@ class Profile(models.Model):
     def get_tags_speech_topic_formatted(self) -> List[str]:
         return [tag.name for tag in self.tags_speech_topic.all()]
 
-    def get_public_local_groups_member_of(self):
+    def get_public_local_groups_member_of(self) -> List[LocalGroup]:
         return self.local_groups.filter(is_public=True)
 
-    def get_public_local_groups_organising(self):
-        return [group for group in LocalGroup.objects.all() if group.organisers.filter(id=self.user.id).exists() and group.is_public]
+    def get_public_local_groups_organising(self) -> List[LocalGroup]:
+        return [
+            group
+            for group in LocalGroup.objects.all()
+            if group.organisers.filter(id=self.user.id).exists() and group.is_public
+        ]
 
     def get_local_groups_formatted(self) -> List[str]:
         return [group.name for group in self.get_public_local_groups_member_of()]

--- a/eahub/profiles/models.py
+++ b/eahub/profiles/models.py
@@ -401,11 +401,17 @@ class Profile(models.Model):
     def get_tags_speech_topic_formatted(self) -> List[str]:
         return [tag.name for tag in self.tags_speech_topic.all()]
 
+    def get_public_local_groups_member_of(self):
+        return self.local_groups.filter(is_public=True)
+
+    def get_public_local_groups_organising(self):
+        return [group for group in LocalGroup.objects.all() if group.organisers.filter(id=self.user.id).exists() and group.is_public]
+
     def get_local_groups_formatted(self) -> List[str]:
-        return [group.name for group in self.local_groups.all()]
+        return [group.name for group in self.get_public_local_groups_member_of()]
 
     def get_organizer_of_local_groups_formatted(self) -> List[str]:
-        return [group.name for group in self.user.localgroup_set.all()]
+        return [group.name for group in self.get_public_local_groups_organising()]
 
     def get_image_placeholder(self) -> str:
         return f"Avatar{self.id % 10}.jpg"

--- a/eahub/profiles/templates/profiles/profile.html
+++ b/eahub/profiles/templates/profiles/profile.html
@@ -341,16 +341,16 @@
                 </div>
               {% endif %}
 
-              {% if profile.local_groups.exists %}
+              {% if profile.get_public_local_groups_member_of.exists %}
                 <div class="card__section">
                   <div class="card__subtitle">Local group membership</div>
-                  {% if profile.local_groups.all.count == 1 %}
+                  {% if profile.get_public_local_groups_member_of|length == 1 %}
                     <a href="{% url 'group' profile.local_groups.first.slug %}">
-                      {{ profile.local_groups.first.name }}
+                      {{ profile.get_public_local_groups_member_of.first.name }}
                     </a>
                   {% else %}
                     <ul>
-                      {% for group in profile.local_groups.all %}
+                      {% for group in profile.get_public_local_groups_member_of %}
                         <li>
                           <a class="list-item"
                             href="{% url 'group' group.slug %}"
@@ -362,21 +362,25 @@
                 </div>
               {% endif %}
 
-              {% if profile.user.localgroup_set.exists %}
+              {% if profile.get_public_local_groups_organising %}
                 <div class="card__section">
                   <div class="card__subtitle">Organiser of</div>
-                  {% if profile.user.localgroup_set.all.count == 1 %}
+                  {% if profile.get_public_local_groups_organising|length == 1 %}
                     <a
-                      href="{% url 'group' profile.user.localgroup_set.first.slug %}"
+                      href="{% url 'group' profile.get_public_local_groups_organising.0.slug %}"
                     >
-                      {{ profile.user.localgroup_set.first.name }}
+                      {{ profile.get_public_local_groups_organising.0.name }}
                     </a>
                   {% else %}
-                    {% for group in profile.user.localgroup_set.all %}
-                      <a class="list-item"
-                        href="{% url 'group' group.slug %}"
-                      >{{ group.name }}</a>, 
+                    <ul>
+                    {% for group in profile.get_public_local_groups_organising %}
+                      <li>
+                        <a class="list-item"
+                          href="{% url 'group' group.slug %}"
+                        >{{ group }}</a>
+                      </li>
                     {% endfor %}
+                    </ul>
                   {% endif %}
                 </div>
               {% endif %}

--- a/eahub/profiles/tests/test_profile_models.py
+++ b/eahub/profiles/tests/test_profile_models.py
@@ -155,9 +155,15 @@ class ProfileTestCase(EAHubTestCase):
 
     def test_get_public_local_groups_organising(self):
         profile = self.gen.profile()
-        group_not_public = self.gen.group(organisers=[profile.user], is_public=False, name="NonPublicGroup")
-        group_public = self.gen.group(organisers=[profile.user], is_public=True, name="PublicGroupOrganising")
-        group_member_of_not_organising = self.gen.group(members=[profile.user], is_public=True, name="PublicGroupMemberOf")
+        group_not_public = self.gen.group(
+            organisers=[profile.user], is_public=False, name="NonPublicGroup"
+        )
+        group_public = self.gen.group(
+            organisers=[profile.user], is_public=True, name="PublicGroupOrganising"
+        )
+        group_member_of_not_organising = self.gen.group(
+            members=[profile.user], is_public=True, name="PublicGroupMemberOf"
+        )
 
         groups_organising = profile.get_public_local_groups_organising()
 
@@ -167,12 +173,10 @@ class ProfileTestCase(EAHubTestCase):
         profile = self.gen.profile()
         group_not_public = self.gen.group(members=[profile.user], is_public=False)
         group_public = self.gen.group(members=[profile.user], is_public=True)
-        group_not_member_of = self.gen.group(members=[self.gen.profile().user], is_public=True)
+        group_not_member_of = self.gen.group(
+            members=[self.gen.profile().user], is_public=True
+        )
 
         groups_member_of = profile.get_public_local_groups_member_of()
 
         self.assertCountEqual([group_public], groups_member_of)
-
-
-
-

--- a/eahub/profiles/tests/test_profile_models.py
+++ b/eahub/profiles/tests/test_profile_models.py
@@ -152,3 +152,27 @@ class ProfileTestCase(EAHubTestCase):
                 for x in analytics_logs_update
             )
         )
+
+    def test_get_public_local_groups_organising(self):
+        profile = self.gen.profile()
+        group_not_public = self.gen.group(organisers=[profile.user], is_public=False, name="NonPublicGroup")
+        group_public = self.gen.group(organisers=[profile.user], is_public=True, name="PublicGroupOrganising")
+        group_member_of_not_organising = self.gen.group(members=[profile.user], is_public=True, name="PublicGroupMemberOf")
+
+        groups_organising = profile.get_public_local_groups_organising()
+
+        self.assertCountEqual([group_public], groups_organising)
+
+    def test_get_local_groups(self):
+        profile = self.gen.profile()
+        group_not_public = self.gen.group(members=[profile.user], is_public=False)
+        group_public = self.gen.group(members=[profile.user], is_public=True)
+        group_not_member_of = self.gen.group(members=[self.gen.profile().user], is_public=True)
+
+        groups_member_of = profile.get_public_local_groups_member_of()
+
+        self.assertCountEqual([group_public], groups_member_of)
+
+
+
+

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -81,9 +81,9 @@
         {% if group.city_or_town %}<li class="list-group-item"><b>City/Town: </b>{{ group.city_or_town }}</li>{% endif %}
         {% if group.region %}<li class="list-group-item"><b>Region: </b>{{ group.region }}</li>{% endif %}
         {% if group.country %}<li class="list-group-item"><b>Country: </b>{{ group.country }}</li>{% endif %}
-        {% if group.public_organisers or (user.id is not None and user.is_approved and group.public_and_internal_organisers) or group.organisers_freetext %}
+        {% if group.public_organisers or user.id is not None and user.profile.is_approved and group.public_and_internal_organisers or group.organisers_freetext %}
         <li class="list-group-item"><b>Organisers:</b>
-          {% if user.id is not None and user.is_approved %}
+          {% if user.id is not None and user.profile.is_approved %}
           {% for organiser in group.public_and_internal_organisers %}
             <a href="{{ organiser.profile.get_absolute_url }}" rel="nofollow">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
           {% endfor %}

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -85,11 +85,11 @@
         <li class="list-group-item"><b>Organisers:</b>
           {% if user.id is not None and user.profile.is_approved %}
           {% for organiser in group.public_and_internal_organisers %}
-            <a href="{{ organiser.profile.get_absolute_url }}" rel="nofollow">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
+            <a href="{{ organiser.profile.get_absolute_url }}">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
           {% endfor %}
           {% else %}
           {% for organiser in group.public_organisers %}
-            <a href="{{ organiser.profile.get_absolute_url }}" rel="nofollow">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
+            <a href="{{ organiser.profile.get_absolute_url }}">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
           {% endfor %}
           {% endif %}
           {{ group.organisers_freetext }}

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -25,7 +25,7 @@
     </div>
     <div class="col-xs-12 col-md-6">
       <h1 class="word-break">{{ group.name }}</h1>
-      {% if request.user.id is not None %}
+      {% if request.user.id is not None and request.user.profile.is_approved %}
       {% if group.has_organisers_with_messaging_enabled or group.email %}
       <div class="btn btn-default purple">
         <a href="{% url 'message_group' group.slug  %}"><i class="fa fa-envelope"></i> Send Message</a>
@@ -81,11 +81,17 @@
         {% if group.city_or_town %}<li class="list-group-item"><b>City/Town: </b>{{ group.city_or_town }}</li>{% endif %}
         {% if group.region %}<li class="list-group-item"><b>Region: </b>{{ group.region }}</li>{% endif %}
         {% if group.country %}<li class="list-group-item"><b>Country: </b>{{ group.country }}</li>{% endif %}
-        {% if group.public_organisers or group.organisers_freetext %}
+        {% if group.public_organisers or (user.id is not None and user.is_approved and group.public_and_internal_organisers) or group.organisers_freetext %}
         <li class="list-group-item"><b>Organisers:</b>
+          {% if user.id is not None and user.is_approved %}
+          {% for organiser in group.public_and_internal_organisers %}
+            <a href="{{ organiser.profile.get_absolute_url }}" rel="nofollow">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
+          {% endfor %}
+          {% else %}
           {% for organiser in group.public_organisers %}
             <a href="{{ organiser.profile.get_absolute_url }}" rel="nofollow">{{ organiser.profile.get_full_name }}</a>{% if forloop.counter < group.public_organisers.count or group.organisers_freetext %}, {% endif %}
           {% endfor %}
+          {% endif %}
           {{ group.organisers_freetext }}
         </li>
         {% endif %}

--- a/eahub/tests/cases.py
+++ b/eahub/tests/cases.py
@@ -12,6 +12,7 @@ from eahub.profiles.models import (
     ProfileTagType,
     ProfileTagTypeEnum,
     VisibilityEnum,
+    Membership
 )
 
 
@@ -19,17 +20,24 @@ class Gen:
     def __init__(self):
         self.faker = Faker()
 
-    def group(self, **kwargs) -> LocalGroup:
-        users = kwargs.pop("users")
+    def group(self, organisers=None, members=None, **kwargs) -> LocalGroup:
         group = baker.make(
             "localgroups.LocalGroup",
             slug="",
             name=kwargs.pop("name", self.faker.unique.company()),
             **kwargs,
         )
-        for user in users:
-            o = Organisership(user=user, local_group=group)
-            o.save()
+
+        if organisers:
+            for organiser in organisers:
+                o = Organisership(user=organiser, local_group=group)
+                o.save()
+
+        if members:
+            for member in members:
+                m = Membership(profile=member.profile, local_group=group)
+                m.save()
+
         return group
 
     def profile(self, **kwargs) -> Profile:

--- a/eahub/tests/cases.py
+++ b/eahub/tests/cases.py
@@ -5,7 +5,7 @@ from faker import Faker
 from model_bakery import baker
 
 from eahub.base.models import User
-from eahub.localgroups.models import LocalGroup
+from eahub.localgroups.models import LocalGroup, Organisership
 from eahub.profiles.models import (
     Profile,
     ProfileTag,
@@ -20,12 +20,17 @@ class Gen:
         self.faker = Faker()
 
     def group(self, **kwargs) -> LocalGroup:
-        return baker.make(
+        users = kwargs.pop("users")
+        group = baker.make(
             "localgroups.LocalGroup",
             slug="",
             name=kwargs.pop("name", self.faker.unique.company()),
             **kwargs,
         )
+        for user in users:
+            o = Organisership(user=user, local_group=group)
+            o.save()
+        return group
 
     def profile(self, **kwargs) -> Profile:
         return baker.make(

--- a/eahub/tests/cases.py
+++ b/eahub/tests/cases.py
@@ -12,7 +12,7 @@ from eahub.profiles.models import (
     ProfileTagType,
     ProfileTagTypeEnum,
     VisibilityEnum,
-    Membership
+    Membership,
 )
 
 


### PR DESCRIPTION
* Shows internal users as organisers on group page if user is logged in. It previously did not show internal users as organisers in any case    
* Fixes bugs with displaying membership and organisership on group page:  
  * If a group is not public, on the group organiser's profiles page the group is not shown. It previously showed also non-public groups.    

  * Shows the groups a user is organising, rather than a member of, under heading "Organiser". It previously showed who they are a member of  
* Some refactoring of group test helper code



Closes #1264  