### PR TITLE
Enable internal organisers and give staff access to group edit page

### DIFF
--- a/eahub/base/adapter.py
+++ b/eahub/base/adapter.py
@@ -25,7 +25,7 @@ class EmailBlacklistingAdapter(adapter.DefaultAccountAdapter):
                 code="blacklisted",
             )
         return email
-    
+
     def get_login_redirect_url(self, request: HttpRequest) -> str:
         redirect_url = request.POST.get("next", "")
         if redirect_url:

--- a/eahub/base/management/commands/eag_export_for_mailchimp.py
+++ b/eahub/base/management/commands/eag_export_for_mailchimp.py
@@ -20,10 +20,10 @@ class Command(base.BaseCommand):
                     profile = Profile.objects.get(user__email=line.strip())
                 except Profile.DoesNotExist:
                     continue
-                
+
                 if (
-                    profile.visibility == VisibilityEnum.PRIVATE and
-                    not profile.user.password
+                    profile.visibility == VisibilityEnum.PRIVATE
+                    and not profile.user.password
                 ):
                     password_reset_link = reverse(
                         "account_reset_password_from_key",
@@ -43,8 +43,8 @@ class Command(base.BaseCommand):
                         ]
                     )
                 elif (
-                    profile.visibility == VisibilityEnum.PRIVATE and
-                    profile.user.password
+                    profile.visibility == VisibilityEnum.PRIVATE
+                    and profile.user.password
                 ):
                     df_mailchimp_raw.append(
                         [

--- a/eahub/localgroups/forms.py
+++ b/eahub/localgroups/forms.py
@@ -27,6 +27,9 @@ class UserMultipleChoiceField(forms.ModelMultipleChoiceField):
             models.Q(
                 profile__visibility=VisibilityEnum.PUBLIC, profile__is_approved=True
             )
+            | models.Q(
+                profile__visibility=VisibilityEnum.INTERNAL, profile__is_approved=True
+            )
             | models.Q(already_selected=True)
             | models.Q(pk=user.pk)
         )

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -3,16 +3,22 @@ import rules
 from ..profiles.models import Profile
 
 
-
 def is_organiser(user, local_group):
     return local_group.organisers.filter(pk=user.pk).exists()
 
+
 @rules.predicate
 def can_edit_group(user, local_group):
-    return user.has_perm("localgroups.change_localgroup") or is_organiser(user, local_group)
+    return user.has_perm("localgroups.change_localgroup") or is_organiser(
+        user, local_group
+    )
+
 
 def can_delete_group(user, local_group):
-    return user.has_perm("localgroups.delete_localgroup") or is_organiser(user, local_group)
+    return user.has_perm("localgroups.delete_localgroup") or is_organiser(
+        user, local_group
+    )
+
 
 @rules.predicate
 def is_approved(user):

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -13,7 +13,7 @@ def can_edit_group(user, local_group):
         user, local_group
     )
 
-
+@rules.predicate
 def can_delete_group(user, local_group):
     return user.has_perm("localgroups.delete_localgroup") or is_organiser(
         user, local_group

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -13,6 +13,7 @@ def can_edit_group(user, local_group):
         user, local_group
     )
 
+
 @rules.predicate
 def can_delete_group(user, local_group):
     return user.has_perm("localgroups.delete_localgroup") or is_organiser(

--- a/eahub/localgroups/rules.py
+++ b/eahub/localgroups/rules.py
@@ -3,10 +3,16 @@ import rules
 from ..profiles.models import Profile
 
 
-@rules.predicate
+
 def is_organiser(user, local_group):
     return local_group.organisers.filter(pk=user.pk).exists()
 
+@rules.predicate
+def can_edit_group(user, local_group):
+    return user.has_perm("localgroups.change_localgroup") or is_organiser(user, local_group)
+
+def can_delete_group(user, local_group):
+    return user.has_perm("localgroups.delete_localgroup") or is_organiser(user, local_group)
 
 @rules.predicate
 def is_approved(user):
@@ -18,5 +24,5 @@ def is_approved(user):
 
 
 rules.add_perm("localgroups.create_local_group", is_approved)
-rules.add_perm("localgroups.change_local_group", is_organiser)
-rules.add_perm("localgroups.delete_local_group", is_organiser)
+rules.add_perm("localgroups.edit_group", can_edit_group)
+rules.add_perm("localgroups.delete_group", can_delete_group)

--- a/eahub/localgroups/tests/test_localgroups_forms.py
+++ b/eahub/localgroups/tests/test_localgroups_forms.py
@@ -14,5 +14,7 @@ class LocalGroupFormsTestCase(EAHubTestCase):
         form = LocalGroupForm(user=profile_public.user)
         organisers_to_choose_from = form.fields["organisers"].queryset
 
-        self.assertCountEqual([profile_public.user, profile_internal.user], organisers_to_choose_from)
+        self.assertCountEqual(
+            [profile_public.user, profile_internal.user], organisers_to_choose_from
+        )
         self.assertNotIn(profile_private.user, organisers_to_choose_from)

--- a/eahub/localgroups/tests/test_localgroups_forms.py
+++ b/eahub/localgroups/tests/test_localgroups_forms.py
@@ -1,0 +1,18 @@
+from eahub.base.models import User
+from eahub.localgroups.forms import LocalGroupForm
+from eahub.localgroups.models import LocalGroup, Organisership
+from eahub.profiles.models import Profile, VisibilityEnum
+from eahub.tests.cases import EAHubTestCase
+
+
+class LocalGroupFormsTestCase(EAHubTestCase):
+    def test_organisers_field(self):
+        profile_public = self.gen.profile(visibility=VisibilityEnum.PUBLIC)
+        profile_internal = self.gen.profile(visibility=VisibilityEnum.INTERNAL)
+        profile_private = self.gen.profile(visibility=VisibilityEnum.PRIVATE)
+
+        form = LocalGroupForm(user=profile_public.user)
+        organisers_to_choose_from = form.fields["organisers"].queryset
+
+        self.assertCountEqual([profile_public.user, profile_internal.user], organisers_to_choose_from)
+        self.assertNotIn(profile_private.user, organisers_to_choose_from)

--- a/eahub/localgroups/tests/test_localgroups_views.py
+++ b/eahub/localgroups/tests/test_localgroups_views.py
@@ -1,0 +1,82 @@
+from django.contrib.auth.models import Permission
+from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
+
+from eahub.localgroups.models import LocalGroup
+from eahub.tests.cases import EAHubTestCase
+
+
+class GroupViewTestCase(EAHubTestCase):
+    def test_group_edit_no_access_to_ordinary_user(self):
+        group = self.gen.group()
+
+        profile_visitor = self.gen.profile(is_approved=True)
+        self.client.force_login(profile_visitor.user)
+
+        self.assert_post_status_code("localgroups_update", group.slug, 403)
+        self.assert_get_status_code("localgroups_update", group.slug, 403)
+
+    def test_group_edit_access_to_organiser(self):
+        profile = self.gen.profile(is_approved=True)
+        self.client.force_login(profile.user)
+
+        group = self.gen.group(organisers=[profile.user])
+
+        self.assert_post_status_code("localgroups_update", group.slug, 200)
+        self.assert_get_status_code("localgroups_update", group.slug, 200)
+
+    def test_group_edit_access_to_staff(self):
+        profile = self.gen.profile(is_approved=True)
+
+        content_type = ContentType.objects.get_for_model(LocalGroup)
+        permission = Permission.objects.get(
+            codename="change_localgroup", content_type=content_type
+        )
+        profile.user.user_permissions.add(permission)
+        self.client.force_login(profile.user)
+
+        group = self.gen.group()
+
+        self.assert_post_status_code("localgroups_update", group.slug, 200)
+        self.assert_get_status_code("localgroups_update", group.slug, 200)
+
+    def test_group_delete_not_permitted_for_ordinary_user(self):
+        group = self.gen.group()
+
+        profile_visitor = self.gen.profile(is_approved=True)
+        self.client.force_login(profile_visitor.user)
+
+        self.assert_post_status_code("localgroups_delete", group.slug, 403)
+        self.assert_get_status_code("localgroups_update", group.slug, 403)
+
+    def test_group_delete_permitted_for_organiser(self):
+        profile = self.gen.profile(is_approved=True)
+        self.client.force_login(profile.user)
+
+        group = self.gen.group(organisers=[profile.user])
+
+        self.assert_post_status_code("localgroups_delete", group.slug, 302)
+
+    def test_group_delete_permitted_for_staff(self):
+        profile = self.gen.profile(is_approved=True)
+
+        content_type = ContentType.objects.get_for_model(LocalGroup)
+        permission = Permission.objects.get(
+            codename="delete_localgroup", content_type=content_type
+        )
+        profile.user.user_permissions.add(permission)
+        self.client.force_login(profile.user)
+
+        group = self.gen.group()
+
+        self.assert_post_status_code("localgroups_delete", group.slug, 302)
+
+    def assert_get_status_code(self, url_name, slug, status_code):
+        response_get = self.client.get(reverse(url_name, args=([slug])))
+
+        self.assertEqual(response_get.status_code, status_code)
+
+    def assert_post_status_code(self, url_name, slug, status_code):
+        response_post = self.client.post(reverse(url_name, args=([slug])))
+
+        self.assertEqual(response_post.status_code, status_code)

--- a/eahub/localgroups/tests/test_localgroups_views.py
+++ b/eahub/localgroups/tests/test_localgroups_views.py
@@ -55,7 +55,7 @@ class GroupViewTestCase(EAHubTestCase):
 
         group = self.gen.group(organisers=[profile.user])
 
-        self.assert_post_status_code("localgroups_delete", group.slug, 302)
+        self.assert_post_status_code("localgroups_delete", group.slug, 200)
 
     def test_group_delete_permitted_for_staff(self):
         profile = self.gen.profile(is_approved=True)
@@ -69,14 +69,14 @@ class GroupViewTestCase(EAHubTestCase):
 
         group = self.gen.group()
 
-        self.assert_post_status_code("localgroups_delete", group.slug, 302)
+        self.assert_post_status_code("localgroups_delete", group.slug, 200)
 
     def assert_get_status_code(self, url_name, slug, status_code):
-        response_get = self.client.get(reverse(url_name, args=([slug])))
+        response_get = self.client.get(reverse(url_name, args=([slug])), follow=True)
 
         self.assertEqual(response_get.status_code, status_code)
 
     def assert_post_status_code(self, url_name, slug, status_code):
-        response_post = self.client.post(reverse(url_name, args=([slug])))
+        response_post = self.client.post(reverse(url_name, args=([slug])), follow=True)
 
         self.assertEqual(response_post.status_code, status_code)

--- a/eahub/localgroups/views.py
+++ b/eahub/localgroups/views.py
@@ -65,7 +65,7 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
     queryset = LocalGroup.objects.filter(is_public=True)
     form_class = LocalGroupForm
     template_name = "eahub/edit_group.html"
-    permission_required = "localgroups.change_local_group"
+    permission_required = "localgroups.edit_group"
 
     def get_form_kwargs(self):
         return {**super().get_form_kwargs(), "user": self.request.user}
@@ -84,7 +84,7 @@ class LocalGroupUpdateView(rules_views.PermissionRequiredMixin, edit_views.Updat
 class LocalGroupDeleteView(rules_views.PermissionRequiredMixin, edit_views.DeleteView):
     queryset = LocalGroup.objects.filter(is_public=True)
     template_name = "eahub/delete_group.html"
-    permission_required = "localgroups.delete_local_group"
+    permission_required = "localgroups.delete_group"
 
     def delete(self, *args, **kwargs):
         self.object = self.get_object()

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -33,7 +33,7 @@
       {% endif %}
       {% endif %}
 
-      {% has_perm 'localgroups.change_local_group' user group as can_edit_local_group %}
+      {% has_perm 'localgroups.edit_group' user group as can_edit_local_group %}
       {% if can_edit_local_group %}
         <a href="{% url 'localgroups_update' group.slug %}">
           <div class="btn btn-default purple">
@@ -111,7 +111,7 @@
       </div>
       <div class="panel-body">
         {{ group.other_info|default:'N/A'|urlize|linebreaks }}
-        {% has_perm 'localgroups.change_local_group' user group as can_edit_local_group %}
+        {% has_perm 'localgroups.medit_group' user group as can_edit_local_group %}
         {% if can_edit_local_group %}
           <br>
           <a href="{% url 'localgroups_update' group.slug %}">

--- a/eahub/templates/eahub/group.html
+++ b/eahub/templates/eahub/group.html
@@ -111,7 +111,7 @@
       </div>
       <div class="panel-body">
         {{ group.other_info|default:'N/A'|urlize|linebreaks }}
-        {% has_perm 'localgroups.medit_group' user group as can_edit_local_group %}
+        {% has_perm 'localgroups.edit_group' user group as can_edit_local_group %}
         {% if can_edit_local_group %}
           <br>
           <a href="{% url 'localgroups_update' group.slug %}">


### PR DESCRIPTION
- Adds internal profiles to the list of profiles from which group organisers can be chosen  
- Sets permissions such that staff with specific permission to edit groups can view edit group page and make changes 
- Sets permissions such that staff with specific permission to delete groups can delete group from edit group page